### PR TITLE
Warnings as errors only in release build

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,9 +3,13 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <NullableReferenceTypes>true</NullableReferenceTypes>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\analyzers.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration.ToLower())' == 'release'">
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>True</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <Import Project="Packages.props"/>

--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Please see the [code of conduct](CODE_OF_CONDUCT.md) and
 [contributing document](CONTRIBUTING.MD) for details on contributing to
 this project.
 
-## Dependencies
+## Development
+
+### Dependencies
 
 The target is .NET Core 3.1 for development (netcoreapp3.1)
+
+### Building
+
+Warnings are treated as errors in the release build (as in CI builds) but are left as warnings in local development.
+To verify your code is warning-free, you can run `dotnet build --configuration Release` to get the release build behavior.

--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ The target is .NET Core 3.1 for development (netcoreapp3.1)
 
 ### Building
 
-Warnings are treated as errors in the release build (as in CI builds) but are left as warnings in local development.
-To verify your code is warning-free, you can run `dotnet build --configuration Release` to get the release build behavior.
+Warnings are treated as errors in the release build (as in CI builds) but are
+left as warnings in local development. To verify your code is warning-free, you
+can run `dotnet build --configuration Release` to get the release build behavior.


### PR DESCRIPTION
## Description

This changes the behavior of the build to allow warnings without failing during local development. That means things like "elements should be documented" will not fail the build on a developer's machine and will allow testing and running to continue.

Warnings will still be treated as errors for release builds as executed by the GitHub Actions CI build. Individual developers can replicate the behavior by specifying the build configuration: `dotnet build --configuration Release`.

This comes from a @lugolven recommendation here: https://github.com/CBielstein/APRSsharp/pull/19#discussion_r445873420

## Changes

* Wrap warnings as errors properties in a conditional property group
* Updated readme
* Took the chance to specify `MSBuildTreatWarningsAsErrors` as recommended by @lugolven

## Verification

* Wrote a method that created some warnings and observed the warnings did NOT cause a failure with `dotnet build` but do cause failures with `dotnet build --configuration Release`