### PR TITLE
Decreased timeout on Actions to 5 minutes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,11 @@ on:
   pull_request:
     branches:
       - main
-   
 
 jobs:
   build:
     name: build
-
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     steps:
@@ -33,5 +32,3 @@ jobs:
         
       - name: Test
         run: dotnet test --no-restore
-
-

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   lint:
     name: Lint
-
+    timeout-minutes: 5
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -10,6 +10,7 @@ on:
       - main
     paths:
       - '**/*.md'
+      - '.github/workflows/**'
 
 jobs:
   lint:


### PR DESCRIPTION
## Description

Having recently seen examples of runaway Actions that hang, I'm adding a lower timeout. Default timeout is 360 minutes, which is much, much too high. This changes it to 5 minutes.
This provides faster feedback on failures and feedback at all if we hugely balloon build time. Although we don't have to pay for Actions minutes as a public repository, we should not expect our Actions times to explode by a factor of 5 with no warning.

## Changes

* Added timeout to both workflow files
* Modified markdown lint workflow to ensure the Action always runs if any workflow files are changed

## Verification

* Checked that there are no runs that take even 30% of that time
* Actions will run with new time limits as part of this PR