### PR TITLE
Add IDisposableAnalyzers and fix violations

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -4,5 +4,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="IDisposableAnalyzers" Version="3.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/src/KissTnc/TncInterface.cs
+++ b/src/KissTnc/TncInterface.cs
@@ -7,7 +7,7 @@ namespace AprsSharp.Protocols
     /// <summary>
     /// Represents an interface through a serial connection to a TNC using the KISS protocol.
     /// </summary>
-    public class TNCInterface
+    public class TNCInterface : IDisposable
     {
         /// <summary>
         /// The serial port to which the TNC is connected.
@@ -33,6 +33,8 @@ namespace AprsSharp.Protocols
         /// The port on the TNC used for communication.
         /// </summary>
         private byte tncPort = 0;
+
+        private bool disposed;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TNCInterface"/> class.
@@ -71,6 +73,18 @@ namespace AprsSharp.Protocols
         /// </summary>
         public event FrameReceivedEventHandler? FrameReceivedEvent;
 
+        /// <inheritdoc/>
+        public virtual void Dispose()
+        {
+            if (disposed)
+            {
+                return;
+            }
+
+            disposed = true;
+            serialPort?.Dispose();
+        }
+
         /// <summary>
         /// Sets a new serial port to use for the TNC.
         /// If an existing port is open, closes it.
@@ -84,6 +98,7 @@ namespace AprsSharp.Protocols
             }
 
             serialPort?.Close();
+            serialPort?.Dispose();
 
             serialPort = new SerialPort(serialPortName);
             serialPort.DataReceived += new SerialDataReceivedEventHandler(TNCDataReceivedEventHandler);

--- a/test/KissTncUnitTests/TNCInterfaceUnitTests.cs
+++ b/test/KissTncUnitTests/TNCInterfaceUnitTests.cs
@@ -17,7 +17,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void EncodeFrameData1()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             tnc.SetTncPort(0);
 
             string message = "TEST";
@@ -42,7 +42,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void EncodeFrameData2()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             tnc.SetTncPort(5);
 
             string message = "Hello";
@@ -65,7 +65,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void EncodeFrameDataWithEscapes()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             tnc.SetTncPort(0);
 
             byte[] data = new byte[2] { (byte)SpecialCharacters.FEND, (byte)SpecialCharacters.FESC };
@@ -88,7 +88,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void EncodeFrameExitKissMode()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             tnc.SetTncPort(0);
 
             byte[] encodedBytes = tnc.ExitKISSMode();
@@ -109,7 +109,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DataReceivedAtOnce()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
 
             byte[] receivedData = new byte[7] { 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0 };
 
@@ -126,7 +126,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DataReceivedSplit()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
 
             byte[] dataRec1 = new byte[4] { 0xC0, 0x50, 0x48, 0x65 };
             byte[] dataRec2 = new byte[4] { 0x6C, 0x6C, 0x6F, 0xC0 };
@@ -146,7 +146,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DataReceivedEscapes()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
 
             byte[] recData = new byte[7] { 0xC0, 0x00, 0xDB, 0xDC, 0xDB, 0xDD, 0xC0 };
 
@@ -164,7 +164,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DataReceivedAtOncePrefacedMultipleFEND()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
 
             byte[] receivedData = new byte[9] { (byte)SpecialCharacters.FEND, (byte)SpecialCharacters.FEND, 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0 };
 
@@ -181,7 +181,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void MultipleFramesDataReceivedAtOnce()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
 
             byte[] receivedData = new byte[15] { 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0, 0xC0, 0x50, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0xC0 };
 
@@ -200,7 +200,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DelegateReceivedAtOnce()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
 
             tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
@@ -222,7 +222,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DelegateDataReceivedSplit()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
 
             tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
@@ -248,7 +248,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DelegateDataReceivedEscapes()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
 
             tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
@@ -271,7 +271,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DelegateDataReceivedAtOncePrefacedMultipleFEND()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
 
             tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
@@ -293,7 +293,7 @@ namespace AprsSharpUnitTests.Protocols
         [TestMethod]
         public void DelegateMultipleFramesDataReceivedAtOnce()
         {
-            TNCInterface tnc = new TNCInterface();
+            using TNCInterface tnc = new TNCInterface();
             Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
 
             tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);


### PR DESCRIPTION
## Description

Adds a new static analyzer in the form of [IDisposableAnalyzers](https://www.nuget.org/packages/IDisposableAnalyzers/). The new analyzer immediately caught a violation where the project was not properly disposing a system-level resource, so this change also cleans that up. This is part of #27.

## Changes

* Add IDisposableAnalyzers to the common packages imported by all projects
* Fix violations of the new analyzer

## Verification

* Build passes locally