### PR TITLE
Use `Assert.Throws` for tests expecting an exception

### DIFF
--- a/test/AprsParserUnitTests/PacketUnitTests.cs
+++ b/test/AprsParserUnitTests/PacketUnitTests.cs
@@ -21,25 +21,18 @@
         {
             Packet p = new Packet();
 
-            try
-            {
-                p.DecodeInformationField("_10090556c220s004g005t077r000p000P000h50b09900wRSW");
+            Assert.Throws<NotImplementedException>(() => p.DecodeInformationField("_10090556c220s004g005t077r000p000P000h50b09900wRSW"));
 
-                throw new System.Exception("Update test. It's now outdated as more functionality has been added.");
-            }
-            catch (System.NotImplementedException)
-            {
-                Assert.Equal(Packet.Type.WeatherReport, p.DecodedType);
-                Assert.Equal(false, p.HasMessaging);
+            Assert.Equal(Packet.Type.WeatherReport, p.DecodedType);
+            Assert.Equal(false, p.HasMessaging);
 
-                Timestamp? ts = p.Timestamp;
-                Assert.NotNull(ts);
-                Assert.Equal(Timestamp.Type.MDHM, ts!.DecodedType);
-                Assert.Equal(10, ts!.DateTime.Month);
-                Assert.Equal(9, ts!.DateTime.Day);
-                Assert.Equal(05, ts!.DateTime.Hour);
-                Assert.Equal(56, ts!.DateTime.Minute);
-            }
+            Timestamp? ts = p.Timestamp;
+            Assert.NotNull(ts);
+            Assert.Equal(Timestamp.Type.MDHM, ts!.DecodedType);
+            Assert.Equal(10, ts!.DateTime.Month);
+            Assert.Equal(9, ts!.DateTime.Day);
+            Assert.Equal(05, ts!.DateTime.Hour);
+            Assert.Equal(56, ts!.DateTime.Minute);
         }
 
         /// <summary>
@@ -495,17 +488,7 @@
         public void GetTypeChar_DoNotUse()
         {
             Packet p = new Packet();
-
-            try
-            {
-                p.GetTypeChar(Packet.Type.DoNotUse);
-
-                Assert.True(false, "Should have thrown exception.");
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
+            Assert.Throws<ArgumentException>(() => p.GetTypeChar(Packet.Type.DoNotUse));
         }
 
         /// <summary>

--- a/test/AprsParserUnitTests/PositionUnitTests.cs
+++ b/test/AprsParserUnitTests/PositionUnitTests.cs
@@ -46,16 +46,7 @@
             string latitude = "9103.50N";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLatitude(latitude);
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentOutOfRangeException");
+            Assert.Throws<ArgumentOutOfRangeException>(() => p.DecodeLatitude(latitude));
         }
 
         /// <summary>
@@ -67,16 +58,7 @@
             string latitude = "4cam.50N";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLatitude(latitude);
-            }
-            catch (FormatException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown a FormatException");
+            Assert.Throws<FormatException>(() => p.DecodeLatitude(latitude));
         }
 
         /// <summary>
@@ -88,16 +70,7 @@
             string latitude = "4903.500N";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLatitude(latitude);
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentOutOfRangeException.");
+            Assert.Throws<ArgumentException>(() => p.DecodeLatitude(latitude));
         }
 
         /// <summary>
@@ -109,16 +82,7 @@
             string latitude = "4903.50E";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLatitude(latitude);
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentException.");
+            Assert.Throws<ArgumentException>(() => p.DecodeLatitude(latitude));
         }
 
         /// <summary>
@@ -130,16 +94,7 @@
             string latitude = "490.350N";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLatitude(latitude);
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentException.");
+            Assert.Throws<ArgumentException>(() => p.DecodeLatitude(latitude));
         }
 
         /// <summary>
@@ -207,18 +162,7 @@
             string latitude = "49  .1  N";
             Position p = new Position();
 
-            try
-            {
-                p.CountAmbiguity(latitude);
-
-                Assert.True(false, "This should have thrown an exception.");
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
-
-            Assert.True(false, "This should have thrown an ArgumentException.");
+            Assert.Throws<ArgumentException>(() => p.CountAmbiguity(latitude));
         }
 
         /// <summary>
@@ -256,18 +200,7 @@
             string latitude = "4903.50N";
             Position p = new Position();
 
-            try
-            {
-                string ambiguous = p.EnforceAmbiguity(latitude, 7);
-
-                Assert.True(false, "Should have thrown an exception.");
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentOutOfRangeException.");
+            Assert.Throws<ArgumentOutOfRangeException>(() => p.EnforceAmbiguity(latitude, 7));
         }
 
         /// <summary>
@@ -305,16 +238,7 @@
             string longitude = "18130.50E";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLongitude(longitude);
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentOutOfRangeException");
+            Assert.Throws<ArgumentOutOfRangeException>(() => p.DecodeLongitude(longitude));
         }
 
         /// <summary>
@@ -326,16 +250,7 @@
             string longitude = "4cam0.50E";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLongitude(longitude);
-            }
-            catch (FormatException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown a FormatException");
+            Assert.Throws<FormatException>(() => p.DecodeLongitude(longitude));
         }
 
         /// <summary>
@@ -347,16 +262,7 @@
             string longitude = "072010.50W";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLongitude(longitude);
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentException");
+            Assert.Throws<ArgumentException>(() => p.DecodeLongitude(longitude));
         }
 
         /// <summary>
@@ -368,16 +274,7 @@
             string longitude = "07201.50N";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLongitude(longitude);
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentException.");
+            Assert.Throws<ArgumentException>(() => p.DecodeLongitude(longitude));
         }
 
         /// <summary>
@@ -389,16 +286,7 @@
             string longitude = "072.0175W";
             Position p = new Position();
 
-            try
-            {
-                p.DecodeLongitude(longitude);
-            }
-            catch (ArgumentException)
-            {
-                return;
-            }
-
-            Assert.True(false, "Should have thrown an ArgumentException.");
+            Assert.Throws<ArgumentException>(() => p.DecodeLongitude(longitude));
         }
 
         /// <summary>

--- a/test/AprsParserUnitTests/TimestampUnitTests.cs
+++ b/test/AprsParserUnitTests/TimestampUnitTests.cs
@@ -17,17 +17,7 @@
         {
             Timestamp ts = new Timestamp();
 
-            try
-            {
-                ts.FindCorrectYearAndMonth(32, DateTime.Now, out _, out _);
-
-                // Should not reach here as an ArgumentOutOfRangeException should be thrown
-                Assert.True(false);
-            }
-            catch (Exception e)
-            {
-                Assert.IsType<ArgumentOutOfRangeException>(e);
-            }
+            Assert.Throws<ArgumentOutOfRangeException>(() => ts.FindCorrectYearAndMonth(32, DateTime.Now, out _, out _));
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Use `Assert.Throws` for tests expecting an exception

## Changes

Changed try..catch blocks in tests to Assert.Throws<>

## Validation

Confirmed Build succeeded and tests passed
