### PR TITLE
Enable FxCop Analyzers in KissTnc directories

### DIFF
--- a/src/KissTnc/FrameReceivedEventArgs.cs
+++ b/src/KissTnc/FrameReceivedEventArgs.cs
@@ -1,6 +1,7 @@
-namespace AprsSharp.Protocols
+namespace AprsSharp.Protocols.KISS
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Caries the bytes delivered in a single frame by the TNC.
@@ -19,7 +20,7 @@ namespace AprsSharp.Protocols
         /// <summary>
         /// Gets the data bytes of the received frame.
         /// </summary>
-        public byte[] Data
+        public IReadOnlyList<byte> Data
         {
             get;
             private set;

--- a/src/KissTnc/KISSProtocolValues.cs
+++ b/src/KissTnc/KISSProtocolValues.cs
@@ -1,11 +1,11 @@
-namespace AprsSharp.Protocols
+namespace AprsSharp.Protocols.KISS
 {
     /// <summary>
     /// Represents special characters in the KISS protocol.
     /// All values and descriptions taken from KA9Q's KISS paper.
     /// http://www.ka9q.net/papers/kiss.html.
     /// </summary>
-    public enum SpecialCharacters
+    public enum SpecialCharacter
     {
         /// <summary>
         /// Frame End
@@ -32,18 +32,18 @@ namespace AprsSharp.Protocols
     /// Represents codes used to command the TNC in the KISS protocol.
     /// These are embedded in the encoding of frames sent to the TNC.
     /// </summary>
-    public enum Commands
+    public enum Command
     {
         /// <summary>
         /// The rest of the frame is data to be sent on the HDLC channel.
         /// </summary>
-        DATA_FRAME = 0,
+        DataFrame = 0,
 
         /// <summary>
         /// The next byte is the transmitter keyup delay in 10 ms units.
         /// The default start-up value is 50 (i.e., 500 ms).
         /// </summary>
-        TX_DELAY = 1,
+        TxDelay = 1,
 
         /// <summary>
         /// The next byte is the persistence parameter, p, scaled to the
@@ -56,26 +56,26 @@ namespace AprsSharp.Protocols
         /// The next byte is the slot interval in 10 ms units.
         /// The default is 10 (i.e. 100ms).
         /// </summary>
-        SLOT_TIME = 3,
+        SlotTime = 3,
 
         /// <summary>
         /// The next byte is the time to hold up the TX after the FCS has been sent,
         /// in 10 MS units. This command is obsolete, and is included here only for
         /// compatibility with some existing implementations.
         /// </summary>
-        TX_TAIL = 4,
+        TxTail = 4,
 
         /// <summary>
         /// The next byte is 0 for half duplex, nonzero for full duplex.
         /// The default is 0 (i.e., half duplex).
         /// </summary>
-        FULL_DUPLEX = 5,
+        FullDuplex = 5,
 
         /// <summary>
         /// Specific for each TNC. In the TNC-1, this command sets the modem speed.
         /// Other implementations may use this function for other hardware-specific functions.
         /// </summary>
-        SET_HARDWARE = 6,
+        SetHardware = 6,
 
         /// <summary>
         /// Exit KISS and return control to a higher-level program. This is useful

--- a/src/KissTnc/KissTnc.csproj
+++ b/src/KissTnc/KissTnc.csproj
@@ -6,6 +6,10 @@
 
   <ItemGroup>
     <PackageReference Include="System.IO.Ports" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/KissTnc/TncInterface.cs
+++ b/src/KissTnc/TncInterface.cs
@@ -113,7 +113,7 @@ namespace AprsSharp.Protocols.KISS
             // ensure this is just the size of a nibble
             if (port < 0 || port > 0xF)
             {
-                throw new ArgumentOutOfRangeException(nameof(port), "Port value must be a nibble in range [0, 0xF], but was instead " + port);
+                throw new ArgumentOutOfRangeException(nameof(port), $"Port value must be a nibble in range [0, 0xF], but was instead: {port}");
             }
 
             tncPort = port;
@@ -160,7 +160,7 @@ namespace AprsSharp.Protocols.KISS
         {
             if (p < 0 || p > 255)
             {
-                throw new ArgumentOutOfRangeException(nameof(p), "p should be in range [0, 255], but was " + p);
+                throw new ArgumentOutOfRangeException(nameof(p), $"p should be in range [0, 255], but was {p}");
             }
 
             return EncodeAndSend(Command.P, new byte[1] { p });

--- a/src/KissTnc/TncInterface.cs
+++ b/src/KissTnc/TncInterface.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Protocols
+namespace AprsSharp.Protocols.KISS
 {
     using System;
     using System.Collections.Generic;
@@ -7,7 +7,7 @@ namespace AprsSharp.Protocols
     /// <summary>
     /// Represents an interface through a serial connection to a TNC using the KISS protocol.
     /// </summary>
-    public class TNCInterface : IDisposable
+    public sealed class TNCInterface : IDisposable
     {
         /// <summary>
         /// The serial port to which the TNC is connected.
@@ -22,17 +22,17 @@ namespace AprsSharp.Protocols
         /// <summary>
         /// Marks if the next character received should be translated as an escaped character.
         /// </summary>
-        private bool inEscapeMode = false;
+        private bool inEscapeMode;
 
         /// <summary>
         /// Tracks if the previously received byte was FEND, so we can skip the control byte which comes next.
         /// </summary>
-        private bool previousWasFEND = false;
+        private bool previousWasFEND;
 
         /// <summary>
         /// The port on the TNC used for communication.
         /// </summary>
-        private byte tncPort = 0;
+        private byte tncPort;
 
         private bool disposed;
 
@@ -74,7 +74,7 @@ namespace AprsSharp.Protocols
         public event FrameReceivedEventHandler? FrameReceivedEvent;
 
         /// <inheritdoc/>
-        public virtual void Dispose()
+        public void Dispose()
         {
             if (disposed)
             {
@@ -94,7 +94,7 @@ namespace AprsSharp.Protocols
         {
             if (serialPortName == null)
             {
-                throw new ArgumentNullException("serialPortName");
+                throw new ArgumentNullException(nameof(serialPortName));
             }
 
             serialPort?.Close();
@@ -113,7 +113,7 @@ namespace AprsSharp.Protocols
             // ensure this is just the size of a nibble
             if (port < 0 || port > 0xF)
             {
-                throw new ArgumentOutOfRangeException("port", "Port value must be a nibble in range [0, 0xF], but was instead " + port);
+                throw new ArgumentOutOfRangeException(nameof(port), "Port value must be a nibble in range [0, 0xF], but was instead " + port);
             }
 
             tncPort = port;
@@ -128,14 +128,14 @@ namespace AprsSharp.Protocols
         {
             if (bytes == null)
             {
-                throw new ArgumentNullException("bytes");
+                throw new ArgumentNullException(nameof(bytes));
             }
             else if (bytes.Length == 0)
             {
-                throw new ArgumentException("Bytes to send has length zero.", "bytes");
+                throw new ArgumentException("Bytes to send has length zero.", nameof(bytes));
             }
 
-            return EncodeAndSend(Commands.DATA_FRAME, bytes);
+            return EncodeAndSend(Command.DataFrame, bytes);
         }
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace AprsSharp.Protocols
         /// <returns>The encoded bytes.</returns>
         public byte[] SetTxDelay(byte delay)
         {
-            return EncodeAndSend(Commands.TX_DELAY, new byte[1] { delay });
+            return EncodeAndSend(Command.TxDelay, new byte[1] { delay });
         }
 
         /// <summary>
@@ -160,10 +160,10 @@ namespace AprsSharp.Protocols
         {
             if (p < 0 || p > 255)
             {
-                throw new ArgumentOutOfRangeException("p", "p should be in range [0, 255], but was " + p);
+                throw new ArgumentOutOfRangeException(nameof(p), "p should be in range [0, 255], but was " + p);
             }
 
-            return EncodeAndSend(Commands.P, new byte[1] { p });
+            return EncodeAndSend(Command.P, new byte[1] { p });
         }
 
         /// <summary>
@@ -174,7 +174,7 @@ namespace AprsSharp.Protocols
         /// <returns>The encoded bytes.</returns>
         public byte[] SetSlotTime(byte slotTime)
         {
-            return EncodeAndSend(Commands.SLOT_TIME, new byte[1] { slotTime });
+            return EncodeAndSend(Command.SlotTime, new byte[1] { slotTime });
         }
 
         /// <summary>
@@ -185,7 +185,7 @@ namespace AprsSharp.Protocols
         /// <returns>The encoded bytes.</returns>
         public byte[] SetTxTail(byte time)
         {
-            return EncodeAndSend(Commands.TX_TAIL, new byte[1] { time });
+            return EncodeAndSend(Command.TxTail, new byte[1] { time });
         }
 
         /// <summary>
@@ -197,7 +197,7 @@ namespace AprsSharp.Protocols
         {
             byte commandByte = (state == DuplexState.FullDuplex) ? (byte)1 : (byte)0;
 
-            return EncodeAndSend(Commands.FULL_DUPLEX, new byte[1] { commandByte });
+            return EncodeAndSend(Command.FullDuplex, new byte[1] { commandByte });
         }
 
         /// <summary>
@@ -207,7 +207,7 @@ namespace AprsSharp.Protocols
         /// <returns>The encoded bytes.</returns>
         public byte[] SetHardwareSpecific(byte value)
         {
-            return EncodeAndSend(Commands.SET_HARDWARE, new byte[1] { value });
+            return EncodeAndSend(Command.SetHardware, new byte[1] { value });
         }
 
         /// <summary>
@@ -216,7 +216,7 @@ namespace AprsSharp.Protocols
         /// <returns>The encoded bytes.</returns>
         public byte[] ExitKISSMode()
         {
-            return EncodeAndSend(Commands.RETURN, Array.Empty<byte>());
+            return EncodeAndSend(Command.RETURN, Array.Empty<byte>());
         }
 
         /// <summary>
@@ -231,13 +231,18 @@ namespace AprsSharp.Protocols
         {
             Queue<byte[]> receivedFrames = new Queue<byte[]>();
 
+            if (newBytes == null)
+            {
+                throw new ArgumentNullException(nameof(newBytes));
+            }
+
             foreach (byte recByte in newBytes)
             {
                 byte? byteToEnqueue = null;
 
                 if (previousWasFEND)
                 {
-                    previousWasFEND = recByte == (byte)SpecialCharacters.FEND;
+                    previousWasFEND = recByte == (byte)SpecialCharacter.FEND;
                     continue;
                 }
 
@@ -246,17 +251,17 @@ namespace AprsSharp.Protocols
                 {
                     switch (recByte)
                     {
-                        case (byte)SpecialCharacters.TFESC:
-                            byteToEnqueue = (byte)SpecialCharacters.FESC;
+                        case (byte)SpecialCharacter.TFESC:
+                            byteToEnqueue = (byte)SpecialCharacter.FESC;
                             break;
 
-                        case (byte)SpecialCharacters.TFEND:
-                            byteToEnqueue = (byte)SpecialCharacters.FEND;
+                        case (byte)SpecialCharacter.TFEND:
+                            byteToEnqueue = (byte)SpecialCharacter.FEND;
                             break;
 
                         default:
                             // Not really an escape, push on the previously unused FESC character and move on
-                            receivedBuffer.Enqueue((byte)SpecialCharacters.FESC);
+                            receivedBuffer.Enqueue((byte)SpecialCharacter.FESC);
                             break;
                     }
 
@@ -268,7 +273,7 @@ namespace AprsSharp.Protocols
                 {
                     switch (recByte)
                     {
-                        case (byte)SpecialCharacters.FEND:
+                        case (byte)SpecialCharacter.FEND:
                             byte[] deliverBytes = receivedBuffer.ToArray();
                             receivedBuffer.Clear();
                             previousWasFEND = true;
@@ -281,7 +286,7 @@ namespace AprsSharp.Protocols
 
                             break;
 
-                        case (byte)SpecialCharacters.FESC:
+                        case (byte)SpecialCharacter.FESC:
                             inEscapeMode = true;
                             break;
 
@@ -307,26 +312,26 @@ namespace AprsSharp.Protocols
         /// <param name="port">The port to address on the TNC.</param>
         /// <param name="bytes">Optionally, bytes to encode.</param>
         /// <returns>Encoded bytes.</returns>
-        private byte[] EncodeFrame(Commands command, byte port, byte[] bytes)
+        private static byte[] EncodeFrame(Command command, byte port, byte[] bytes)
         {
             // We will need at least FEND, command byte, bytes, FEND. Potentially more as bytes could have characters needing escape.
             Queue<byte> frame = new Queue<byte>(3 + ((bytes == null) ? 0 : bytes.Length));
 
-            frame.Enqueue((byte)SpecialCharacters.FEND);
+            frame.Enqueue((byte)SpecialCharacter.FEND);
             frame.Enqueue((byte)((port << 4) | (byte)command));
 
             foreach (byte b in bytes ?? Array.Empty<byte>())
             {
                 switch (b)
                 {
-                    case (byte)SpecialCharacters.FEND:
-                        frame.Enqueue((byte)SpecialCharacters.FESC);
-                        frame.Enqueue((byte)SpecialCharacters.TFEND);
+                    case (byte)SpecialCharacter.FEND:
+                        frame.Enqueue((byte)SpecialCharacter.FESC);
+                        frame.Enqueue((byte)SpecialCharacter.TFEND);
                         break;
 
-                    case (byte)SpecialCharacters.FESC:
-                        frame.Enqueue((byte)SpecialCharacters.FESC);
-                        frame.Enqueue((byte)SpecialCharacters.TFESC);
+                    case (byte)SpecialCharacter.FESC:
+                        frame.Enqueue((byte)SpecialCharacter.FESC);
+                        frame.Enqueue((byte)SpecialCharacter.TFESC);
                         break;
 
                     default:
@@ -335,7 +340,7 @@ namespace AprsSharp.Protocols
                 }
             }
 
-            frame.Enqueue((byte)SpecialCharacters.FEND);
+            frame.Enqueue((byte)SpecialCharacter.FEND);
 
             return frame.ToArray();
         }
@@ -367,7 +372,7 @@ namespace AprsSharp.Protocols
         /// <param name="command">Command / frame time to encode.</param>
         /// <param name="data">Data to send.</param>
         /// <returns>The encoded bytes.</returns>
-        private byte[] EncodeAndSend(Commands command, byte[] data)
+        private byte[] EncodeAndSend(Command command, byte[] data)
         {
             byte[] encodedBytes = EncodeFrame(command, tncPort, data);
 

--- a/test/KissTncUnitTests/KissTncUnitTests.csproj
+++ b/test/KissTncUnitTests/KissTncUnitTests.csproj
@@ -10,6 +10,10 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/KissTncUnitTests/TNCInterfaceUnitTests.cs
+++ b/test/KissTncUnitTests/TNCInterfaceUnitTests.cs
@@ -1,8 +1,10 @@
 namespace AprsSharpUnitTests.Protocols
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
-    using AprsSharp.Protocols;
+    using AprsSharp.Protocols.KISS;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     /// <summary>
@@ -68,7 +70,7 @@ namespace AprsSharpUnitTests.Protocols
             using TNCInterface tnc = new TNCInterface();
             tnc.SetTncPort(0);
 
-            byte[] data = new byte[2] { (byte)SpecialCharacters.FEND, (byte)SpecialCharacters.FESC };
+            byte[] data = new byte[2] { (byte)SpecialCharacter.FEND, (byte)SpecialCharacter.FESC };
 
             byte[] encodedBytes = tnc.SendData(data);
 
@@ -154,8 +156,8 @@ namespace AprsSharpUnitTests.Protocols
 
             Assert.AreEqual(1, decodedFrames.Length);
             Assert.AreEqual(2, decodedFrames[0].Length);
-            Assert.AreEqual((byte)SpecialCharacters.FEND, decodedFrames[0][0]);
-            Assert.AreEqual((byte)SpecialCharacters.FESC, decodedFrames[0][1]);
+            Assert.AreEqual((byte)SpecialCharacter.FEND, decodedFrames[0][0]);
+            Assert.AreEqual((byte)SpecialCharacter.FESC, decodedFrames[0][1]);
         }
 
         /// <summary>
@@ -166,7 +168,7 @@ namespace AprsSharpUnitTests.Protocols
         {
             using TNCInterface tnc = new TNCInterface();
 
-            byte[] receivedData = new byte[9] { (byte)SpecialCharacters.FEND, (byte)SpecialCharacters.FEND, 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0 };
+            byte[] receivedData = new byte[9] { (byte)SpecialCharacter.FEND, (byte)SpecialCharacter.FEND, 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0 };
 
             byte[][] decodedFrames = tnc.DecodeReceivedData(receivedData);
 
@@ -201,19 +203,19 @@ namespace AprsSharpUnitTests.Protocols
         public void DelegateReceivedAtOnce()
         {
             using TNCInterface tnc = new TNCInterface();
-            Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
+            Queue<IReadOnlyList<byte>> decodedFrames = new Queue<IReadOnlyList<byte>>();
 
-            tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
+            tnc.FrameReceivedEvent += (sender, arg) => decodedFrames.Enqueue(arg.Data);
 
             byte[] receivedData = new byte[7] { 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0 };
 
             tnc.DecodeReceivedData(receivedData);
 
-            byte[][] decodedFrames = qDecodedFrames.ToArray();
+            Assert.AreEqual(1, decodedFrames.Count);
 
-            Assert.AreEqual(1, decodedFrames.Length);
-            Assert.AreEqual(4, decodedFrames[0].Length);
-            Assert.AreEqual("TEST", Encoding.ASCII.GetString(decodedFrames[0]));
+            IReadOnlyList<byte> frame = decodedFrames.Dequeue();
+            Assert.AreEqual(4, frame.Count);
+            Assert.AreEqual("TEST", Encoding.ASCII.GetString(frame.ToArray()));
         }
 
         /// <summary>
@@ -223,23 +225,24 @@ namespace AprsSharpUnitTests.Protocols
         public void DelegateDataReceivedSplit()
         {
             using TNCInterface tnc = new TNCInterface();
-            Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
+            Queue<IReadOnlyList<byte>> decodedFrames = new Queue<IReadOnlyList<byte>>();
 
-            tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
+            tnc.FrameReceivedEvent += (sender, arg) => decodedFrames.Enqueue(arg.Data);
 
             byte[] dataRec1 = new byte[4] { 0xC0, 0x50, 0x48, 0x65 };
             byte[] dataRec2 = new byte[4] { 0x6C, 0x6C, 0x6F, 0xC0 };
 
             tnc.DecodeReceivedData(dataRec1);
 
-            byte[][] decodedFrames = qDecodedFrames.ToArray();
+            Assert.AreEqual(0, decodedFrames.Count);
 
-            Assert.AreEqual(0, decodedFrames.Length);
+            tnc.DecodeReceivedData(dataRec2);
 
-            decodedFrames = tnc.DecodeReceivedData(dataRec2);
-            Assert.AreEqual(1, decodedFrames.Length);
-            Assert.AreEqual(5, decodedFrames[0].Length);
-            Assert.AreEqual("Hello", Encoding.ASCII.GetString(decodedFrames[0]));
+            Assert.AreEqual(1, decodedFrames.Count);
+
+            IReadOnlyList<byte> frame = decodedFrames.Dequeue();
+            Assert.AreEqual(5, frame.Count);
+            Assert.AreEqual("Hello", Encoding.ASCII.GetString(frame.ToArray()));
         }
 
         /// <summary>
@@ -249,20 +252,20 @@ namespace AprsSharpUnitTests.Protocols
         public void DelegateDataReceivedEscapes()
         {
             using TNCInterface tnc = new TNCInterface();
-            Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
+            Queue<IReadOnlyList<byte>> decodedFrames = new Queue<IReadOnlyList<byte>>();
 
-            tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
+            tnc.FrameReceivedEvent += (sender, arg) => decodedFrames.Enqueue(arg.Data);
 
             byte[] recData = new byte[7] { 0xC0, 0x00, 0xDB, 0xDC, 0xDB, 0xDD, 0xC0 };
 
             tnc.DecodeReceivedData(recData);
 
-            byte[][] decodedFrames = qDecodedFrames.ToArray();
+            Assert.AreEqual(1, decodedFrames.Count);
 
-            Assert.AreEqual(1, decodedFrames.Length);
-            Assert.AreEqual(2, decodedFrames[0].Length);
-            Assert.AreEqual((byte)SpecialCharacters.FEND, decodedFrames[0][0]);
-            Assert.AreEqual((byte)SpecialCharacters.FESC, decodedFrames[0][1]);
+            IReadOnlyList<byte> frame = decodedFrames.Dequeue();
+            Assert.AreEqual(2, frame.Count);
+            Assert.AreEqual((byte)SpecialCharacter.FEND, frame[0]);
+            Assert.AreEqual((byte)SpecialCharacter.FESC, frame[1]);
         }
 
         /// <summary>
@@ -272,19 +275,19 @@ namespace AprsSharpUnitTests.Protocols
         public void DelegateDataReceivedAtOncePrefacedMultipleFEND()
         {
             using TNCInterface tnc = new TNCInterface();
-            Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
+            Queue<IReadOnlyList<byte>> decodedFrames = new Queue<IReadOnlyList<byte>>();
 
-            tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
+            tnc.FrameReceivedEvent += (sender, arg) => decodedFrames.Enqueue(arg.Data);
 
-            byte[] receivedData = new byte[9] { (byte)SpecialCharacters.FEND, (byte)SpecialCharacters.FEND, 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0 };
+            byte[] receivedData = new byte[9] { (byte)SpecialCharacter.FEND, (byte)SpecialCharacter.FEND, 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0 };
 
             tnc.DecodeReceivedData(receivedData);
 
-            byte[][] decodedFrames = qDecodedFrames.ToArray();
+            Assert.AreEqual(1, decodedFrames.Count);
 
-            Assert.AreEqual(1, decodedFrames.Length);
-            Assert.AreEqual(4, decodedFrames[0].Length);
-            Assert.AreEqual("TEST", Encoding.ASCII.GetString(decodedFrames[0]));
+            IReadOnlyList<byte> frame = decodedFrames.Dequeue();
+            Assert.AreEqual(4, frame.Count);
+            Assert.AreEqual("TEST", Encoding.ASCII.GetString(frame.ToArray()));
         }
 
         /// <summary>
@@ -294,21 +297,23 @@ namespace AprsSharpUnitTests.Protocols
         public void DelegateMultipleFramesDataReceivedAtOnce()
         {
             using TNCInterface tnc = new TNCInterface();
-            Queue<byte[]> qDecodedFrames = new Queue<byte[]>();
+            Queue<IReadOnlyList<byte>> decodedFrames = new Queue<IReadOnlyList<byte>>();
 
-            tnc.FrameReceivedEvent += (sender, arg) => qDecodedFrames.Enqueue(arg.Data);
+            tnc.FrameReceivedEvent += (sender, arg) => decodedFrames.Enqueue(arg.Data);
 
             byte[] receivedData = new byte[15] { 0xC0, 0x00, 0x54, 0x45, 0x53, 0x54, 0xC0, 0xC0, 0x50, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0xC0 };
 
             tnc.DecodeReceivedData(receivedData);
 
-            byte[][] decodedFrames = qDecodedFrames.ToArray();
+            Assert.AreEqual(2, decodedFrames.Count);
 
-            Assert.AreEqual(2, decodedFrames.Length);
-            Assert.AreEqual(4, decodedFrames[0].Length);
-            Assert.AreEqual("TEST", Encoding.ASCII.GetString(decodedFrames[0]));
-            Assert.AreEqual(5, decodedFrames[1].Length);
-            Assert.AreEqual("Hello", Encoding.ASCII.GetString(decodedFrames[1]));
+            IReadOnlyList<byte> frame = decodedFrames.Dequeue();
+            Assert.AreEqual(4, frame.Count);
+            Assert.AreEqual("TEST", Encoding.ASCII.GetString(frame.ToArray()));
+
+            frame = decodedFrames.Dequeue();
+            Assert.AreEqual(5, frame.Count);
+            Assert.AreEqual("Hello", Encoding.ASCII.GetString(frame.ToArray()));
         }
     }
 }


### PR DESCRIPTION
## Description

This is the first of several changes to incrementally enable FxCopAnalyzers in this repository. FxCopAnalyzers allows us to increase code quality of existing code and ensure code quality of new code. Since there are many FxCop violations in this repository, I'm breaking up the large change in to several smaller changes based on project. I will add FxCopAnalyzers to our project Packages.props once the package is enabled everywhere.

This is part of #27 

## Changes

* Adds FxCopAnalyzers to KissTnc and KissTncUnitTests projects
* Fixes FxCop violations in those projects

## Validation

* `dotnet build -c Release` is successful (no violations) on my machine
* Tests are running successfully
