### PR TITLE
Add an initial codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Each line is a file pattern followed by one or more owners.
+# https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, these will
+# be requested for review when someone opens a pull request
+*       @CBielstein @eddywine


### PR DESCRIPTION
## Description

[Code owners](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners) is a GitHub feature to require approval from specific individuals before PRs can be merged in to the main branch. Code owners are also automatically requested for reviews on PRs, which should help us ensure each PR adds each other in case we forget.

This PR adds an initial CODEOWNERS file which requires approval from either @CBielstein or @eddywine to merge code in to this repository.

## Changes

* Add `CODEOWNERS` file as described above.

## Validation

* Will be validated after submitting this PR (new PRs should automatically add code owners, etc.)
