### PR TITLE
Enable FxCop in AprsParserUnitTests directory

### DIFF
--- a/test/AprsParserUnitTests/AprsParserUnitTests.csproj
+++ b/test/AprsParserUnitTests/AprsParserUnitTests.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AprsParserUnitTests/NmeaDataUnitTests.cs
+++ b/test/AprsParserUnitTests/NmeaDataUnitTests.cs
@@ -18,7 +18,7 @@
         [InlineData(NmeaData.Type.Unknown, "POO")]
         [InlineData(NmeaData.Type.WPT, "wpt")]
         [InlineData(NmeaData.Type.WPT, "wpl")]
-        public void GetTypeFromIdentifier(in NmeaData.Type expected, in string input)
+        public void GetTypeFromIdentifier(NmeaData.Type expected, string input)
         {
             Assert.Equal(expected, NmeaData.GetType(input));
         }

--- a/test/AprsParserUnitTests/NmeaDataUnitTests.cs
+++ b/test/AprsParserUnitTests/NmeaDataUnitTests.cs
@@ -9,38 +9,25 @@
     public class NmeaDataUnitTests
     {
         /// <summary>
-        /// Tests GetType.
+        /// Tests GetType from a type identifier.
         /// </summary>
-        [Fact]
-        public void GetType_FromIdentifier_1()
+        /// <param name="expected">Expected NmeaData.Type returned by test.</param>
+        /// <param name="input">Input string to test.</param>
+        [Theory]
+        [InlineData(NmeaData.Type.GGA, "GGA")]
+        [InlineData(NmeaData.Type.Unknown, "POO")]
+        [InlineData(NmeaData.Type.WPT, "wpt")]
+        [InlineData(NmeaData.Type.WPT, "wpl")]
+        public void GetTypeFromIdentifier(in NmeaData.Type expected, in string input)
         {
-            Assert.Equal(NmeaData.Type.GGA, NmeaData.GetType("GGA"));
+            Assert.Equal(expected, NmeaData.GetType(input));
         }
 
         /// <summary>
-        /// Tests GetType.
-        /// </summary>
-        [Fact]
-        public void GetType_FromIdentifier_2()
-        {
-            Assert.Equal(NmeaData.Type.Unknown, NmeaData.GetType("POO"));
-        }
-
-        /// <summary>
-        /// Tests GetType.
-        /// </summary>
-        [Fact]
-        public void GetType_FromIdentifier_3()
-        {
-            Assert.Equal(NmeaData.Type.WPT, NmeaData.GetType("wpt"));
-            Assert.Equal(NmeaData.Type.WPT, NmeaData.GetType("wpl"));
-        }
-
-        /// <summary>
-        /// Tests GetType.
+        /// Tests GetType from a full NMEA string.
         /// </summary>
         [Fact(Skip = "Issue #24: Fix skipped tests from old repository")]
-        public void GetType_FromRawString_4()
+        public void GetTypeFromRawString()
         {
             Assert.Equal(NmeaData.Type.RMC, NmeaData.GetType("$GPRMC,063909,A,3349.4302,N,11700.3721,W,43.022,89.3,291099,13.6,E*52"));
         }

--- a/test/AprsParserUnitTests/TimestampUnitTests.cs
+++ b/test/AprsParserUnitTests/TimestampUnitTests.cs
@@ -19,100 +19,32 @@
         }
 
         /// <summary>
-        /// Ensures we find the correct month and year when we're in the same month.
+        /// Tests FindCorrectYearAndMonth.
         /// </summary>
-        [Fact]
-        public void FindCorrectYearAndMonth_SameMonth()
+        /// <param name="day">A day to find in the most recent applicable month and year.</param>
+        /// <param name="hintYear">The year for the "hint" (usually the current date).</param>
+        /// <param name="hintMonth">The month for the "hint" (usually the current date).</param>
+        /// <param name="hintDay">The day for the "hint" (usually the current date).</param>
+        /// <param name="expectedYear">The expected resultant year.</param>
+        /// <param name="expectedMonth">The expected resultant month.</param>
+        [Theory]
+        [InlineData(7, 2016, 10, 24, 2016, 10)] // Same Month
+        [InlineData(25, 2016, 10, 24, 2016, 9)] // Previous Month
+        [InlineData(31, 2016, 1, 1, 2015, 12)] // Previous Year
+        [InlineData(30, 2016, 3, 1, 2016, 1)] // Two Months Previous
+        [InlineData(29, 2015, 3, 1, 2015, 1)] // Not leap year (Feb 29, 2015 does NOT exist)
+        [InlineData(29, 2016, 3, 1, 2016, 2)] // Leap year (Feb 29, 2016 DOES exist)
+        public void FindCorrectYearAndMonth(
+            in int day,
+            in int hintYear,
+            in int hintMonth,
+            in int hintDay,
+            in int expectedYear,
+            in int expectedMonth)
         {
-            int expectedYear = 2016;
-            int expectedMonth = 10;
-            DateTime midMonth = new DateTime(expectedYear, expectedMonth, 24);
+            DateTime hint = new DateTime(hintYear, hintMonth, hintDay);
 
-            Timestamp.FindCorrectYearAndMonth(7, midMonth, out int year, out int month);
-
-            Assert.Equal(expectedYear, year);
-            Assert.Equal(expectedMonth, month);
-        }
-
-        /// <summary>
-        /// Ensures we find the correct month and year when the day is from last month.
-        /// </summary>
-        [Fact]
-        public void FindCorrectYearAndMonth_PreviousMonth()
-        {
-            int expectedYear = 2016;
-            int expectedMonth = 9;
-            DateTime midMonth = new DateTime(expectedYear, 10, 24);
-
-            Timestamp.FindCorrectYearAndMonth(25, midMonth, out int year, out int month);
-
-            Assert.Equal(expectedYear, year);
-            Assert.Equal(expectedMonth, month);
-        }
-
-        /// <summary>
-        /// Ensures we find the correct month and year when the day is from last year.
-        /// </summary>
-        [Fact]
-        public void FindCorrectYearAndMonth_PreviousYear()
-        {
-            int expectedYear = 2015;
-            int expectedMonth = 12;
-            DateTime midMonth = new DateTime(2016, 1, 1);
-
-            Timestamp.FindCorrectYearAndMonth(31, midMonth, out int year, out int month);
-
-            Assert.Equal(expectedYear, year);
-            Assert.Equal(expectedMonth, month);
-        }
-
-        /// <summary>
-        /// Ensures we find the correct month and year when the day is from two months ago.
-        /// Skips 2/30, since that day doesn't exist.
-        /// </summary>
-        [Fact]
-        public void FindCorrectYearAndMonth_TwoMonthsAgo()
-        {
-            int expectedYear = 2016;
-            int expectedMonth = 1;
-            DateTime midMonth = new DateTime(expectedYear, 3, 1);
-
-            Timestamp.FindCorrectYearAndMonth(30, midMonth, out int year, out int month);
-
-            Assert.Equal(expectedYear,  year);
-            Assert.Equal(expectedMonth, month);
-        }
-
-        /// <summary>
-        /// Ensures we find the correct month and year when the day is from two months ago.
-        /// Skips 2/29, since that day doesn't exist in 2015.
-        /// </summary>
-        [Fact]
-        public void FindCorrectYearAndMonth_NotLeapYear()
-        {
-            int expectedYear = 2015;
-            int expectedMonth = 1;
-
-            DateTime midMonth = new DateTime(expectedYear, 3, 1);
-
-            Timestamp.FindCorrectYearAndMonth(29, midMonth, out int year, out int month);
-
-            Assert.Equal(expectedYear, year);
-            Assert.Equal(expectedMonth, month);
-        }
-
-        /// <summary>
-        /// Ensures we find the correct month and year when the day is from two months ago.
-        /// Does NOT skip 2/29, since that day DOES exist in 2016.
-        /// </summary>
-        [Fact]
-        public void FindCorrectYearAndMonth_LeapYear()
-        {
-            int expectedYear = 2016;
-            int expectedMonth = 2;
-            DateTime midMonth = new DateTime(expectedYear, 3, 1);
-
-            Timestamp.FindCorrectYearAndMonth(29, midMonth, out int year, out int month);
+            Timestamp.FindCorrectYearAndMonth(day, hint, out int year, out int month);
 
             Assert.Equal(expectedYear, year);
             Assert.Equal(expectedMonth, month);


### PR DESCRIPTION
## Description

Follows up on #60 to enable FxCop in the AprsParserUnitTests. Part of #27.

## Changes

* Enables FxCop in the AprsParserUnitTests project
* Switches test methods to reuse code with inline data
* Other fixes

## Validation

* All tests pass on my machine
