### PR TITLE
Swap overload methods for optional parameters

### DIFF
--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -58,21 +58,15 @@
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Packet"/> class.
-        /// Constructs a new Packet object by decoding the encodedPacket string.
-        /// Really just a shortcut for calling the Decode function.
+        /// If an encoded packet is provided, Decode is used to deocde in to this object.
         /// </summary>
-        /// <param name="encodedPacket">A string encoding of an APRS packet.</param>
-        public Packet(string encodedPacket)
+        /// <param name="encodedPacket">A string encoding of an APRS packet to decode (optional).</param>
+        public Packet(string? encodedPacket = null)
         {
-            Decode(encodedPacket);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Packet"/> class.
-        /// Empty constructor.
-        /// </summary>
-        public Packet()
-        {
+            if (encodedPacket != null)
+            {
+                Decode(encodedPacket);
+            }
         }
 
         /// <summary>
@@ -359,19 +353,9 @@
         /// Returns a string of the APRS Information Field (or the AX.25 Information Field) given the proper encoding.
         /// </summary>
         /// <param name="encodeType">The type of encoding to use.</param>
+        /// <param name="timeType">The type of encoding for the timestamp to use. Optional, defaults to DHMz.</param>
         /// <returns>APRS Information Field as a string.</returns>
-        public string EncodeInformationField(Type encodeType)
-        {
-            return EncodeInformationField(encodeType, Timestamp.Type.DHMz);
-        }
-
-        /// <summary>
-        /// Returns a string of the APRS Information Field (or the AX.25 Information Field) given the proper encoding.
-        /// </summary>
-        /// <param name="encodeType">The type of encoding to use.</param>
-        /// <param name="timeType">The type of encoding for the timestamp to use.</param>
-        /// <returns>APRS Information Field as a string.</returns>
-        public string EncodeInformationField(Type encodeType, Timestamp.Type timeType)
+        public string EncodeInformationField(Type encodeType, Timestamp.Type timeType = Timestamp.Type.DHMz)
         {
             string encodedInfoField = string.Empty;
 

--- a/src/AprsParser/Timestamp.cs
+++ b/src/AprsParser/Timestamp.cs
@@ -29,13 +29,6 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Timestamp"/> class.
-        /// </summary>
-        public Timestamp()
-        {
-        }
-
-        /// <summary>
         /// Represents the type of APRS timestamp.
         /// </summary>
         public enum Type

--- a/src/KissTnc/TncInterface.cs
+++ b/src/KissTnc/TncInterface.cs
@@ -41,7 +41,7 @@ namespace AprsSharp.Protocols.KISS
         /// </summary>
         /// <param name="serialPortName">The name of the SerialPort to use.</param>
         /// <param name="port">The port on the TNC used for communication.</param>
-        public TNCInterface(string? serialPortName, byte port)
+        public TNCInterface(string? serialPortName = null, byte port = 0)
         {
             if (serialPortName != null)
             {
@@ -51,14 +51,6 @@ namespace AprsSharp.Protocols.KISS
             receivedBuffer = new Queue<byte>();
 
             SetTncPort(port);
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TNCInterface"/> class.
-        /// </summary>
-        public TNCInterface()
-            : this(null, 0)
-        {
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

The codebase now has a few places where methods are overloaded when optional parameters could be used instead. This adds to the call stack and bloats code. This PR removes a few unnecessary overloads to aim for reducing code bloat.

This resolves #66.

## Changes

* Combine overloaded methods using optional parameters
* Removed a couple of unused constructor overloads

## Validation

* Build and tests passing
