### PR TITLE
Update outdated documentation and link readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ visualizing APRS digital packets in a straight-forward manner.
 This project is provided as [open source](LICENSE) and developed by the
 community for the community.
 
+### Further Documentation
+
+See supplemental documentation for APRS# constituent projects:
+
+* [AprsParser](src/AprsParser/AprsParser.md)
+* [KissTnc](src/KissTnc/KissTnc.md)
+
 ## Contributions
 
 Please see the [code of conduct](CODE_OF_CONDUCT.md) and

--- a/src/AprsParser/AprsParser.md
+++ b/src/AprsParser/AprsParser.md
@@ -2,6 +2,8 @@
 
 APRS packet parser, encoder, and decoder.
 
-The VS solution has been written as a Xamarin Portable Class Library to support
-.NET Framework, Windows, Windows Phone, Android, and iOS, for cross platform
-compatibility.
+For more information about the APRS protocol, view the following:
+
+* [APRS Protocol Reference 1.01](http://aprs.org/doc/APRS101.PDF)
+* [APRS SPEC Addendum 1.1](http://aprs.org/aprs11.html)
+* [APRS SPEC Addendum 1.2 Proposals](http://aprs.org/aprs12.html)


### PR DESCRIPTION
## Description

Updating outdated documentation and linking the markdown readme files for easier access.

## Changes

* Removes outdated information in AprsParser.md and replaces it with links to the APRS specs
* Links to AprsParser.md and KissTnc.md from README.md

## Validation

* Validated by markdown GitHub Action
