### PR TITLE
Move to .NET 6 and C# 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: DotnetVersion
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.x'
+          dotnet-version: '6.0.x'
           
       - name: restore
         run: dotnet restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <NullableReferenceTypes>true</NullableReferenceTypes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ can run `dotnet build -c Release` to get the release build behavior.
 
 To generate the console application binary, go to the APRSsharp folder
 (`AprsSharp\src\APRSsharp`) and run the command `dotnet publish -c Release` to generate
-the console application and it will be stored in the
-`bin\Release\net6.0\win-x86\publish` folder or run `dotnet publish -c Release -o <outputfolder>`
-to store your binary in a given output folder
+the console application.
+The resulting binary will be placed in
+`bin\Release\net6.0\win-x86\publish`.
+Alternatively, use `dotnet publish -c Release -o <outputfolder>` to specify the
+output directory.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ this project.
 
 ### Dependencies
 
-The target is .NET Core 3.1 for development (netcoreapp3.1)
+The target is .NET 6.0 for development.
 
 ### Building
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ The target is .NET 6.0 for development.
 
 Warnings are treated as errors in the release build (as in CI builds) but are
 left as warnings in local development. To verify your code is warning-free, you
-can run `dotnet build --configuration Release` to get the release build behavior.
+can run `dotnet build -c Release` to get the release build behavior.
 
 ### Generating / Publishing console application binary file
 
 To generate the console application binary, go to the APRSsharp folder
-(AprsSharp\src\APRSsharp) and run the command `dotnet publish` to generate
+(`AprsSharp\src\APRSsharp`) and run the command `dotnet publish -c Release` to generate
 the console application and it will be stored in the
-bin/netcoreapp2.2/Debug/publish folder or run `dotnet publish -o <outputfolder>`
+`bin\Release\net6.0\win-x86\publish` folder or run `dotnet publish -c Release -o <outputfolder>`
 to store your binary in a given output folder

--- a/src/APRSsharp/APRSsharp.csproj
+++ b/src/APRSsharp/APRSsharp.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
- <PropertyGroup>
+  <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -27,27 +27,23 @@
         {
             using TcpConnection tcpConnection = new TcpConnection();
             AprsIsConnection n = new AprsIsConnection(tcpConnection);
-            string callsign;
-            string password;
 
             // get input from the user
             Console.WriteLine("Enter your callsign: ");
-            callsign = Console.ReadLine();
+            string? callsign = Console.ReadLine();
             Console.WriteLine("Enter your password: ");
-            password = Console.ReadLine();
-            string? callsignArg = string.IsNullOrEmpty(callsign) ? null : callsign;
-            string? passwordArg = string.IsNullOrEmpty(password) ? null : password;
+            string? password = Console.ReadLine();
             n.ReceivedTcpMessage += PrintTcpMessage;
-            n.Receive(callsignArg, passwordArg);
+            n.Receive(callsign, password);
 
             // skeleton method that will be used to handle the decoded packets
             Console.WriteLine("Enter the packet name ");
-            var packetName = Console.ReadLine();
+            string packetName = Console.ReadLine() ?? throw new ArgumentNullException(nameof(packetName), "Did not provide packet name");
             Packet p = new Packet();
             p.DecodeInformationField(packetName);
             Timestamp? ts = p.Timestamp;
             Position? pos = p.Position;
             Console.WriteLine($"\nHello, your packet name is, {p.Comment}, at cordinates, {pos?.Coordinates}, and time, {ts?.DateTime.Hour}");
-         }
+        }
     }
 }

--- a/test/AprsParserUnitTests/AprsParserUnitTests.csproj
+++ b/test/AprsParserUnitTests/AprsParserUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/KissTncUnitTests/KissTncUnitTests.csproj
+++ b/test/KissTncUnitTests/KissTncUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
## Description

This PR moves to .NET 6 and C# 10 to enable use of new runtime enhancements and language features. This closes #84.

## Changes

* Changes application projects to target .NET 6.0
* Updates language version to C# 10
* Fixes warnings around newly nullable code in .NET 6.0
* Updates .NET SDK version in GitHub Action
* Updates documentation

## Validation

* `dotnet run` succeeds
* Build and tests pass
* Publish and run succeeds
