### PR TITLE
Use constant string interpolation

### DIFF
--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -1,7 +1,5 @@
 namespace AprsSharp.Parsers.Aprs
 {
-    using System.Diagnostics.CodeAnalysis;
-
     /// <summary>
     /// Holds strings for regex comparisons for reuse.
     /// </summary>
@@ -28,19 +26,19 @@ namespace AprsSharp.Parsers.Aprs
         /// Same as <see cref="MaidenheadGridWithOptionalSymbols"/> but forces full line match.
         /// </summary>
         /// <value></value>
-        public static readonly string MaidenheadGridFullLine = $@"^{MaidenheadGridWithOptionalSymbols}$";
+        public const string MaidenheadGridFullLine = $@"^{MaidenheadGridWithOptionalSymbols}$";
 
         /// <summary>
         /// Matches a Miadenhead Grid in square brackets [] with comment.
         /// Four groups: Full, alphanumeric grid, symbols, comment.
         /// </summary>
-        public static readonly string MaidenheadGridLocatorBeacon = $@"^\[{MaidenheadGridWithOptionalSymbols}\](.+)?$";
+        public const string MaidenheadGridLocatorBeacon = $@"^\[{MaidenheadGridWithOptionalSymbols}\](.+)?$";
 
         /// <summary>
         /// Matches a Status info field with Maidenhead grid and optional comment (comment separated by a space)
         /// Four matches: Full, full maidenhead, alphanumeric grid, symbols, comment.
         /// </summary>
-        public static readonly string StatusWithMaidenheadAndComment = $@"^>({MaidenheadGridWithOptionalSymbols}) ?(.+)?$";
+        public const string StatusWithMaidenheadAndComment = $@"^>({MaidenheadGridWithOptionalSymbols}) ?(.+)?$";
 
         /// <summary>
         /// Matches a PositionWithoutTimestamp info field.
@@ -53,7 +51,7 @@ namespace AprsSharp.Parsers.Aprs
         ///     Symbol code
         ///     Optional comment.
         /// </summary>
-        public static readonly string PositionWithoutTimestamp = $@"^!({PositionLatLongWithSymbols})(.+)?$";
+        public const string PositionWithoutTimestamp = $@"^!({PositionLatLongWithSymbols})(.+)?$";
 
         /// <summary>
         /// Matches a PositionWithTimestamp info field.
@@ -68,6 +66,6 @@ namespace AprsSharp.Parsers.Aprs
         ///         Symbol code
         ///     Optional comment.
         /// </summary>
-        public static readonly string PositionWithTimestamp = $@"^([/@])([0-9]{{6}}[/zh0-9])({PositionLatLongWithSymbols})(.+)?$";
+        public const string PositionWithTimestamp = $@"^([/@])([0-9]{{6}}[/zh0-9])({PositionLatLongWithSymbols})(.+)?$";
     }
 }

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -5,7 +5,6 @@ namespace AprsSharp.Parsers.Aprs
     /// <summary>
     /// Holds strings for regex comparisons for reuse.
     /// </summary>
-    [type: SuppressMessage("Microsoft.Performance", "CA1802:UseLiteralsWhereAppropriate", Justification = ".NET Core does not support interpolated const strings. TODO Issue #81.")]
     internal static class RegexStrings
     {
         /// <summary>


### PR DESCRIPTION
## Description

C#10 introduced the ability for constant string interpolation. This means one constant string can be constructed from other constant strings and performance gains can be realized.

Currently, our regex patterns use string interpolation to include sub-patterns and promote reuse. However, since we haven't been on C#10 until recently, some of these strings could not be constant values.

This PR takes advantage of that and makes the remaining regex patterns constant across the board. This closes #81.

## Changes

* Disable the static analysis suppression now that we're on C#10
* Update string definitions to const

## Validation

* Build and tests pass
