### PR TITLE
Enable custom filter in AprsIsConnection and AprsSharp CLI

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -73,14 +73,19 @@
         {
             using TcpConnection tcpConnection = new TcpConnection();
             AprsIsConnection n = new AprsIsConnection(tcpConnection);
+            n.ReceivedTcpMessage += PrintPacket;
 
             // get input from the user
-            Console.WriteLine("Enter your callsign: ");
+            Console.Write("Enter your callsign: ");
             string? callsign = Console.ReadLine();
-            Console.WriteLine("Enter your password: ");
+
+            Console.Write("Enter your password: ");
             string? password = Console.ReadLine();
-            n.ReceivedTcpMessage += PrintPacket;
-            await n.Receive(callsign, password);
+
+            Console.Write("Enter your filter (optional): ");
+            string? filter = Console.ReadLine();
+
+            await n.Receive(callsign, password, filter);
         }
     }
 }

--- a/src/AprsISLibrary/AprsIsConnection.cs
+++ b/src/AprsISLibrary/AprsIsConnection.cs
@@ -1,10 +1,6 @@
 ﻿namespace AprsSharp.Connections.AprsIs
 {
     using System;
-    using System.IO;
-    using System.Net;
-    using System.Net.Sockets;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -46,12 +42,13 @@
         /// </summary>
         /// <param name="callsign">The users callsign string.</param>
         /// <param name="password">The users password string.</param>
+        /// <param name="filter">The APRS-IS filter string for server-side filtering.</param>
         /// <returns>An async task.</returns>
-        public async Task Receive(string? callsign, string? password)
+        public async Task Receive(string? callsign, string? password, string? filter)
         {
-            callsign = callsign ?? "N0CALL";
-            password = password ?? "-1";
-            string filter = "filter r/50.5039/4.4699/50";
+            callsign ??= "N0CALL";
+            password ??= "-1";
+            filter ??= "filter r/50.5039/4.4699/50";
             string authString = $"user {callsign} pass {password} vers AprsSharp 0.1 {filter}";
             string server = "rotate.aprs2.net";
             bool authenticated = false;


### PR DESCRIPTION
## Description

In order to get customized server-side filtering, we need to expose the ability to customize the filter argument when logging in to an APRS-IS server. This PR addresses that by making filter an optional parameter on AprsIsConnection and allowing input in the AprsSharp CLI.

Note, this is a first part of #63, but does not complete all of it.

## Changes

* Expose the filter argument in `AprsIsConnection.Receive(string?, string?, string?)`
* Add `Console.ReadLine()` input to take the filter on the command line

## Validation

* Build and tests pass
* Manually validated by filtering to different locations and seeing different packets. See attached screenshot. Coordinates are Seattle's Space Needle, observe gridsquare CN87 in position reports

![image](https://user-images.githubusercontent.com/3268813/148495731-571505eb-c61f-4148-8330-9f87b6215404.png)



