### PR TITLE
Move default parameters to CLI instead of server connection

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -75,17 +75,26 @@
             AprsIsConnection n = new AprsIsConnection(tcpConnection);
             n.ReceivedTcpMessage += PrintPacket;
 
+            string? input;
+
             // get input from the user
             Console.Write("Enter your callsign: ");
-            string? callsign = Console.ReadLine();
+            input = Console.ReadLine();
+            string callsign = !string.IsNullOrWhiteSpace(input) ? input : throw new ArgumentException("Callsign must be provided");
 
-            Console.Write("Enter your password: ");
-            string? password = Console.ReadLine();
+            Console.Write("Enter your password (optional): ");
+            input = Console.ReadLine();
+            string password = !string.IsNullOrWhiteSpace(input) ? input : "-1";
+
+            Console.Write("Enter server (optional): ");
+            input = Console.ReadLine();
+            string server = !string.IsNullOrWhiteSpace(input) ? input : "rotate.aprs2.net";
 
             Console.Write("Enter your filter (optional): ");
-            string? filter = Console.ReadLine();
+            input = Console.ReadLine();
+            string filter = !string.IsNullOrWhiteSpace(input) ? input : "r/50.5039/4.4699/50";
 
-            await n.Receive(callsign, password, filter);
+            await n.Receive(callsign, password, server, filter);
         }
     }
 }

--- a/src/AprsISLibrary/AprsIsConnection.cs
+++ b/src/AprsISLibrary/AprsIsConnection.cs
@@ -42,16 +42,19 @@
         /// </summary>
         /// <param name="callsign">The users callsign string.</param>
         /// <param name="password">The users password string.</param>
-        /// <param name="filter">The APRS-IS filter string for server-side filtering.</param>
+        /// <param name="server">The APRS-IS server to contact.</param>
+        /// <param name="filter">The APRS-IS filter string for server-side filtering.
+        /// Null sends no filter, which is not recommended for most clients and servers.</param>
         /// <returns>An async task.</returns>
-        public async Task Receive(string? callsign, string? password, string? filter)
+        public async Task Receive(string callsign, string password, string server, string? filter)
         {
-            callsign ??= "N0CALL";
-            password ??= "-1";
-            filter ??= "filter r/50.5039/4.4699/50";
-            string authString = $"user {callsign} pass {password} vers AprsSharp 0.1 {filter}";
-            string server = "rotate.aprs2.net";
             bool authenticated = false;
+
+            string authString = $"user {callsign} pass {password} vers AprsSharp 0.1";
+            if (filter != null)
+            {
+                authString += $" filter {filter}";
+            }
 
             // Open connection
             tcpConnection.Connect(server, 14580);


### PR DESCRIPTION
## Description

As discussed in #100, a bug was introduced in #98 wherein the default filter input (CLI pushing enter without entering a value) resulted in no packets sent by the server.

This was due to `Console.ReadLine()` returning an empty string when nothing was entered rather than `null` as was incorrectly expected.

This change addresses this by moving all "default parameters" logic to the CLI client and out of the server logic. This is consistent with a separation of concerns between the client handling user input and the server library handling server interaction.

This also allows sidestepping the issue of differentiating between a user not supplying a filter (thus wanting the default) or a user supplying explicitly NO filter (not wanting a default or anything else, e.g. the full feed for a server).

This resolves #100.

## Changes

* Move default parameters logic from the server library to the CLI client
* Expose server as a configurable input (helps me during manual testing of changes)
* Change the filter parameter logic to not require "filter " at the start, the user can simply specify the rules of the filter
* Changed to requiring callsign. "N0CALL" appears to be rejected by servers for connection now anyway. If a user still desires that, they can specify it manually. Password still defaults to the default unverified password of "-1".

## Validation

* Build and tests pass
* Manual validation of both default and provided servers, passwords, and filters and saw packets received. See screenshot below to validate default values (callsign cut out for privacy) returning packets:
![image](https://user-images.githubusercontent.com/3268813/148672636-490833e4-3ce7-4e58-bed9-e752d2b9f539.png)

