### PR TITLE
Add ReceivedPacket event to AprsIsConnection

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -12,33 +12,13 @@
     public class Program
     {
         /// <summary>
-        /// A function matching the delegate event to print the received message.
+        /// A function matching the delegate event to print the received packet.
         /// </summary>
-        /// <param name="tcpMessage">The received tcp message that needs to be decoded and printed.</param>
-        public static void PrintPacket(string tcpMessage)
+        /// <param name="p">A <see cref="Packet"/> to be printed.</param>
+        public static void PrintPacket(Packet p)
         {
-            Packet p;
-
             Console.WriteLine();
-            Console.WriteLine($"Received: {tcpMessage}");
-
-            if (tcpMessage.StartsWith('#'))
-            {
-                Console.WriteLine("    Server message, not decoding.");
-                return;
-            }
-
-            try
-            {
-                p = new Packet(tcpMessage);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"    FAILED: {ex.Message}");
-                return;
-            }
-
-            Console.WriteLine($"    Type: {p.InfoField.Type}");
+            Console.WriteLine($"Received type: {p.InfoField.Type}");
 
             // TODO: Reduce copy/paste below
             // TODO: Clean up position printing:
@@ -73,7 +53,7 @@
         {
             using TcpConnection tcpConnection = new TcpConnection();
             AprsIsConnection n = new AprsIsConnection(tcpConnection);
-            n.ReceivedTcpMessage += PrintPacket;
+            n.ReceivedPacket += PrintPacket;
 
             string? input;
 

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -42,6 +42,8 @@
                 Console.WriteLine($"    Position: {mbi.Position.EncodeGridsquare(4, false)}");
                 Console.WriteLine($"    Comment: {mbi.Comment}");
             }
+
+            Console.WriteLine();
         }
 
         /// <summary>

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -20,8 +20,8 @@
             Console.WriteLine();
             Console.WriteLine($"Received type: {p.InfoField.Type}");
 
-            // TODO: Reduce copy/paste below
-            // TODO: Clean up position printing:
+            // TODO Issue #103: Reduce copy/paste below
+            // TODO Issue #103: Clean up position printing:
                 // * Position lat/long encoding uses symbol IDs, not the most user-friendly
                 // * Gridsquare print out should probably print the correct number of characters based on ambiguitiy
             if (p.InfoField is PositionInfo pi)

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -111,8 +111,10 @@
                             }
                         }
                     }
-
-                    Thread.Sleep(500);
+                    else
+                    {
+                        Thread.Yield();
+                    }
                 }
             });
         }

--- a/src/AprsIsConnection/AprsIsConnection.csproj
+++ b/src/AprsIsConnection/AprsIsConnection.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <ItemGroup>
+    <ProjectReference Include="..\AprsParser\AprsParser.csproj" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
   </PropertyGroup>

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -26,7 +26,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             // Mock underlying TCP connection
             string testMessage = "This is a test message";
             var mockTcpConnection = new Mock<ITcpConnection>();
-            mockTcpConnection.Setup(mock => mock.ReceiveString()).Returns(testMessage);
+            mockTcpConnection.SetupSequence(mock => mock.ReceiveString()).Returns(testMessage).Returns(string.Empty);
 
             // Create connection and register a callback
             var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
@@ -40,7 +40,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);
 
             // Wait to ensure the message is received
-            WaitForCondition(() => eventHandled, 500);
+            WaitForCondition(() => eventHandled, 750);
 
             // Assert the callback was triggered and that the expected message was received.
             Assert.True(eventHandled);

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -101,7 +101,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
 
         /// <summary>
         /// Verifies that the <see cref="AprsIsConnection.ReceivedPacket"/> event is raised when
-        /// a packet is decoded in <see cref="AprsIsConnection.Receive(string?, string?, string?)"/>.
+        /// a packet is decoded in <see cref="AprsIsConnection.Receive(string, string, string, string?)"/>.
         /// </summary>
         [Fact]
         public void ReceivedPacketEvent()

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -127,7 +127,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);
 
             // Wait to ensure the message is received
-            WaitForCondition(() => eventHandled, 750);
+            WaitForCondition(() => eventHandled, 1000);
 
             // Assert the callback was triggered and that the expected message was received.
             Assert.True(eventHandled);

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -4,6 +4,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
     using System.Collections.Generic;
     using System.Threading;
     using AprsSharp.Connections.AprsIs;
+    using AprsSharp.Parsers.Aprs;
     using Moq;
     using Xunit;
 
@@ -13,7 +14,8 @@ namespace AprsSharpUnitTests.Connections.AprsIs
     public class ReceiveUnitTests
     {
         /// <summary>
-        /// <see cref="AprsIsConnection.Receive(string, string, string, string?)"/> raises event on TCP message received.
+        /// Verifies that the <see cref="AprsIsConnection.ReceivedTcpMessage"/> event is raised when
+        /// a TCP message is received in <see cref="AprsIsConnection.Receive(string, string, string, string?)"/>.
         /// </summary>
         [Fact]
         public void ReceivedTcpMessageEvent()
@@ -95,6 +97,59 @@ namespace AprsSharpUnitTests.Connections.AprsIs
 
             mockTcpConnection.Verify(mock => mock.SendString(
                     It.Is<string>(m => m.Equals(expectedLoginMessage, StringComparison.Ordinal))));
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="AprsIsConnection.ReceivedPacket"/> event is raised when
+        /// a packet is decoded in <see cref="AprsIsConnection.Receive(string?, string?, string?)"/>.
+        /// </summary>
+        [Fact]
+        public void ReceivedPacketEvent()
+        {
+            IList<string> tcpMessagesReceived = new List<string>();
+            bool eventHandled = false;
+            Packet? receivedPacket = null;
+
+            // Mock underlying TCP connection
+            string encodedPacket = @"N0CALL>igate,T2serv:>CN76wv\L Lighthouse!";
+            var mockTcpConnection = new Mock<ITcpConnection>();
+            mockTcpConnection.Setup(mock => mock.ReceiveString()).Returns(encodedPacket);
+
+            // Create connection and register a callback
+            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            aprsIs.ReceivedPacket += (Packet p) =>
+            {
+                receivedPacket = p;
+                eventHandled = true;
+            };
+
+            // Receive some packets from it.
+            _ = aprsIs.Receive(null, null, null);
+
+            // Wait to ensure the message is received
+            WaitForCondition(() => eventHandled, 500);
+
+            // Assert the callback was triggered and that the expected message was received.
+            Assert.True(eventHandled);
+
+            if (receivedPacket == null)
+            {
+                Assert.NotNull(receivedPacket);
+            }
+            else
+            {
+                Assert.Equal(PacketType.Status, receivedPacket.InfoField.Type);
+                Assert.IsType<StatusInfo>(receivedPacket.InfoField);
+
+                StatusInfo si = (StatusInfo)receivedPacket.InfoField;
+
+                Assert.NotNull(si.Position);
+                Assert.Equal("CN76wv", si.Position?.EncodeGridsquare(6, false), ignoreCase: true);
+                Assert.Equal('\\', si.Position?.SymbolTableIdentifier);
+                Assert.Equal('L', si.Position?.SymbolCode);
+                Assert.Null(si.Timestamp);
+                Assert.Equal("Lighthouse!", si.Comment);
+            }
         }
 
         /// <summary>

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -127,7 +127,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);
 
             // Wait to ensure the message is received
-            WaitForCondition(() => eventHandled, 500);
+            WaitForCondition(() => eventHandled, 750);
 
             // Assert the callback was triggered and that the expected message was received.
             Assert.True(eventHandled);

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -124,7 +124,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             };
 
             // Receive some packets from it.
-            _ = aprsIs.Receive(null, null, null);
+            _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);
 
             // Wait to ensure the message is received
             WaitForCondition(() => eventHandled, 500);


### PR DESCRIPTION
## Description

This PR adds a new event that is raised when `AprsIsConnection` receives and successfully decodes a packet. This is different than the existing event that is raised on every single TCP message received from the server. This event fully decodes a packet and passes it to the event handler.

The goal of this change is to offload work from the client by reducing the kind of code the client will have to duplicate. Instead of all clients writing the packet decode call, this can be handled directly by the `AprsIsConnection`, reducing requirements on the client to simply handling the packet that is received.

This resolves #80.

## Changes

* Add `ReceivedPacket` event to `ApsIsConnection` and decode packets when there is a subscriber to the event.
* Add testing
* Updated the yield logic on the receive task to only yield when there are no new messages to receive, thus ensuring the client can work as quickly as the server sends messages
* Switched to use `Thread.Yield()` instead of `Thread.Sleep(500)` to ensure the task can be picked up again whenever the scheduler is ready for it

## Validation

* Added a new test for the event
* All tests are passing
* Manual verification, see screenshots below

All successes:
![image](https://user-images.githubusercontent.com/3268813/149255328-7a122648-2ae3-4324-bd8e-80ebbb572559.png)

Write to error output when a message decode fails:
![image](https://user-images.githubusercontent.com/3268813/149255408-5b26f6e7-2bc1-4b1f-9675-4561599a9d7b.png)
