### PR TITLE
Implement decode on PositionWithoutTimestampWithMessaging

### DIFF
--- a/src/AprsParser/InfoField/PositionInfo.cs
+++ b/src/AprsParser/InfoField/PositionInfo.cs
@@ -27,9 +27,10 @@ namespace AprsSharp.Parsers.Aprs
 
             Type = GetPacketType(encodedInfoField);
 
-            if (Type == PacketType.PositionWithoutTimestampNoMessaging)
+            if (Type == PacketType.PositionWithoutTimestampNoMessaging || Type == PacketType.PositionWithoutTimestampWithMessaging)
             {
-                HasMessaging = false;
+                HasMessaging = Type == PacketType.PositionWithoutTimestampWithMessaging;
+
                 Match match = Regex.Match(encodedInfoField, RegexStrings.PositionWithoutTimestamp);
                 match.AssertSuccess(PacketType.PositionWithoutTimestampNoMessaging, nameof(encodedInfoField));
 
@@ -39,13 +40,6 @@ namespace AprsSharp.Parsers.Aprs
                 {
                     Comment = match.Groups[6].Value;
                 }
-            }
-            else if (Type == PacketType.PositionWithoutTimestampWithMessaging)
-            {
-                HasMessaging = true;
-
-                // TODO Issue #92
-                throw new NotImplementedException("Decoding not implemented for position without timestamp (with APRS messaging)");
             }
             else if (Type == PacketType.PositionWithTimestampNoMessaging || Type == PacketType.PositionWithTimestampWithMessaging)
             {

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -63,7 +63,7 @@ namespace AprsSharp.Parsers.Aprs
         ///     Symbol code
         ///     Optional comment.
         /// </summary>
-        public const string PositionWithoutTimestamp = $@"^!({PositionLatLongWithSymbols})(.+)?$";
+        public const string PositionWithoutTimestamp = $@"^[!=]({PositionLatLongWithSymbols})(.+)?$";
 
         /// <summary>
         /// Matches a PositionWithTimestamp info field.

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -127,7 +127,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);
 
             // Wait to ensure the message is received
-            WaitForCondition(() => eventHandled, 1000);
+            WaitForCondition(() => eventHandled, 1250);
 
             // Assert the callback was triggered and that the expected message was received.
             Assert.True(eventHandled);

--- a/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
@@ -281,21 +281,26 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         /// <param name="expectedLatitute">Expected decoded latitute.</param>
         /// <param name="expectedLongitute">Expected decoded longitude.</param>
         /// <param name="expectedAmbiguity">Expected decoded ambiguity.</param>
+        /// <param name="expectedHasMessaging">Expected APRS messaging support.</param>
         [Theory]
-        [InlineData("!4903.50N/07201.75W-Test 001234", "Test 001234", 49.0583, -72.0292, 0)] // no timestamp, no APRS messaging, with comment
-        [InlineData("!49  .  N/072  .  W-", null, 49, -72, 4)] // no timestamp, no APRS messaging, location to nearest degree
-        [InlineData("!4903.50N/07201.75W-Test /A=001234", "Test /A=001234", 49.0583, -72.0292, 0, Skip = "Issue #68: Packet decode does not handle altitude data")]
+        [InlineData("!4903.50N/07201.75W-Test 001234", "Test 001234", 49.0583, -72.0292, 0, false)] // no timestamp, no APRS messaging, with comment
+        [InlineData("=4903.50N/07201.75W-Test 001234", "Test 001234", 49.0583, -72.0292, 0, true)] // no timestamp, yes APRS messaging, with comment
+        [InlineData("!49  .  N/072  .  W-", null, 49, -72, 4, false)] // no timestamp, no APRS messaging, location to nearest degree
+        [InlineData("=49  .  N/072  .  W-", null, 49, -72, 4, true)] // no timestamp, yes APRS messaging, location to nearest degree
+        [InlineData("!4903.50N/07201.75W-Test /A=001234", "Test /A=001234", 49.0583, -72.0292, 0, false, Skip = "Issue #68: Packet decode does not handle altitude data")]
         public void DecodeCompleteLatLongPositionReportFormatWithoutTimestamp(
             string informationField,
             string? expectedComment,
             double expectedLatitute,
             double expectedLongitute,
-            int expectedAmbiguity)
+            int expectedAmbiguity,
+            bool expectedHasMessaging)
         {
             PositionInfo pi = new PositionInfo(informationField);
 
-            Assert.Equal(PacketType.PositionWithoutTimestampNoMessaging, pi.Type);
-            Assert.False(pi.HasMessaging);
+            PacketType expectedPacketType = expectedHasMessaging ? PacketType.PositionWithoutTimestampWithMessaging : PacketType.PositionWithoutTimestampNoMessaging;
+            Assert.Equal(expectedPacketType, pi.Type);
+            Assert.Equal(expectedHasMessaging, pi.HasMessaging);
             Assert.Equal(expectedComment, pi.Comment);
 
             Assert.NotNull(pi.Position);
@@ -311,22 +316,27 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         /// </summary>
         /// <param name="comment">Packet comment.</param>
         /// <param name="ambiguity">Positional ambiguity.</param>
+        /// <param name="hasMessaging">Whether the station supports APRS messaging.</param>
         /// <param name="expectedEncoding">Expected encoding result.</param>
         [Theory]
-        [InlineData("Test 001234", 0, @"!4903.50N/07201.75W-Test 001234")] // With comment, no ambiguity.
-        [InlineData("", 4, "!49  .  N/072  .  W-")] // Without comment, with ambiguity to the nearest degree.
+        [InlineData("Test 001234", 0, false, @"!4903.50N/07201.75W-Test 001234")] // With comment, no ambiguity, no messaging
+        [InlineData("Test 001234", 0, true, @"=4903.50N/07201.75W-Test 001234")] // With comment, no ambiguity, yes messaging
+        [InlineData("", 4, false, "!49  .  N/072  .  W-")] // Without comment, with ambiguity to the nearest degree, no messaging
+        [InlineData("", 4, true, "=49  .  N/072  .  W-")] // Without comment, with ambiguity to the nearest degree, yes messaging
         public void EncodeCompleteLatLongPositionReportFormatWithoutTimestamp(
             string comment,
             int ambiguity,
+            bool hasMessaging,
             string expectedEncoding)
         {
             PositionInfo pi = new PositionInfo(
                 new Position(new GeoCoordinate(49.0583, -72.0292), '/', '-', ambiguity),
-                false,
+                hasMessaging,
                 null,
                 comment);
 
-            Assert.Equal(PacketType.PositionWithoutTimestampNoMessaging, pi.Type);
+            PacketType expectedPacketType = hasMessaging ? PacketType.PositionWithoutTimestampWithMessaging : PacketType.PositionWithoutTimestampNoMessaging;
+            Assert.Equal(expectedPacketType, pi.Type);
 
             Assert.Equal(expectedEncoding, pi.Encode());
         }


### PR DESCRIPTION
## Description

The last of the remaining scenarios in the `PositionInfo` code is decoding `PacketType.PositionWithoutTimestampWithMessaging`. This PR resolves that issue.

Along with #109, this should allow APRS# to encode and decode any complete weather reports and position packets.

This was a pretty straightforward change as most of the code was already implemented. I added some encode and decode tests (encode of this already worked, only decode needed fixing, but more tests are always good!).

All that was left was to merge the "without timestamp" cases of position decode and set messaging support based on the packet type. This pattern follows the decode of the "with timestamp" types just below in the same file.

This will resolve #92.

## Changes

* Added both encode and decode test cases for `PacketType.PositionWithoutTimestampWithMessaging`
* Slight refactor on `PositionInfo.cs` to support decode of `PacketType.PositionWithoutTimestampWithMessaging`
* Removed TODO comment for this issue from the code

## Validation

* Build and tests passing
* Decode works from APRS-IS on the console app. See screenshot below.

![image](https://user-images.githubusercontent.com/3268813/150742452-171e91a2-c4be-4b5f-a6fd-d1337ea59b9e.png)
