### PR TITLE
Create AprsSharp.AprsParser and AprsSharp.AprsIsClient Nuget Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: build
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    name: build
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
+      - name: DotnetVersion
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '6.0.x'
+
+      - name: Restore
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      
+      - name: Test
+        run: dotnet test --configuration Release --no-build
+
+      - name: Pack AprsSharp.AprsParser
+        run: dotnet pack src/AprsParser/AprsParser.csproj --configuration Release --no-build
+
+      - name: Pack AprsSharp.AprsIsClient
+        run: dotnet pack src/AprsIsConnection/AprsIsConnection.csproj --configuration Release --no-build
+
+      - name: Publish AprsShar.AprsParser
+        run: dotnet nuget push src/AprsParser/bin/Release/AprsSharp.AprsParser.*.nupkg --api-key $NUGET_API_KEY
+
+      - name: Publish AprsShar.AprsIsClient
+        run: dotnet nuget push src/AprsIsConnection/bin/Release/AprsSharp.AprsIsClient.*.nupkg --api-key $NUGET_API_KEY

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,6 +5,9 @@
     <NullableReferenceTypes>true</NullableReferenceTypes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\analyzers.ruleset</CodeAnalysisRuleSet>
+    <Version>0.1.0</Version>
+    <Authors>Cameron Bielstein</Authors>
+    <Company>Cameron Bielstein</Company>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration.ToLower())' == 'release'">

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ output directory.
 
 ### Nuget Packages and Release
 
-All packages are versioned together for now via a field in `Directory.Build.props`.
-This means if one package gets a new version, they all do.
-While this is not exactly ideal, this is currently used to manage inter-dependencies during early development.
+All packages are versioned together for now via a field in
+`Directory.Build.props`. This means if one package gets a new version, they all
+do. While this is not exactly ideal, this is currently used to manage
+inter-dependencies during early development.
 
-Maintainers should ensure the version has been updated before creating a new GitHub release.
-Creating a release will publish nuget packages to Nuget.org list.
+Maintainers should ensure the version has been updated before creating a new
+GitHub release. Creating a release will publish nuget packages to Nuget.org
+list.

--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ The resulting binary will be placed in
 `bin\Release\net6.0\win-x86\publish`.
 Alternatively, use `dotnet publish -c Release -o <outputfolder>` to specify the
 output directory.
+
+### Nuget Packages and Release
+
+All packages are versioned together for now via a field in `Directory.Build.props`.
+This means if one package gets a new version, they all do.
+While this is not exactly ideal, this is currently used to manage inter-dependencies during early development.
+
+Maintainers should ensure the version has been updated before creating a new GitHub release.
+Creating a release will publish nuget packages to Nuget.org list.

--- a/src/AprsIsConnection/AprsIsConnection.csproj
+++ b/src/AprsIsConnection/AprsIsConnection.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <PackageId>AprsSharp.AprsIsConnection</PackageId>
+    <PackageId>AprsSharp.AprsIsClient</PackageId>
     <Version>0.1.0</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>

--- a/src/AprsIsConnection/AprsIsConnection.csproj
+++ b/src/AprsIsConnection/AprsIsConnection.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsIsConnection</PackageId>
-    <Version>1.0.0-alpha.1.0.0</Version>
+    <Version>0.0.0</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>
     <Description>Library for sending and receiving packets through the Automatic Packet Reporting System Internet Service (APRS-IS)</Description>

--- a/src/AprsIsConnection/AprsIsConnection.csproj
+++ b/src/AprsIsConnection/AprsIsConnection.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsIsConnection</PackageId>
-    <Version>0.0.0</Version>
+    <Version>0.1.0</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>
     <Description>Library for sending and receiving packets through the Automatic Packet Reporting System Internet Service (APRS-IS)</Description>

--- a/src/AprsIsConnection/AprsIsConnection.csproj
+++ b/src/AprsIsConnection/AprsIsConnection.csproj
@@ -7,9 +7,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsIsClient</PackageId>
-    <Version>0.1.0</Version>
-    <Authors>Cameron Bielstein</Authors>
-    <Company>Cameron Bielstein</Company>
     <Description>Library for sending and receiving packets through the Automatic Packet Reporting System Internet Service (APRS-IS)</Description>
     <PackageTags>ham radio;amateur radio;packet radio;radio;APRS;Automatic Packet Reporting System;Automatic Packet Reporting System Internet System;APRS-IS;</PackageTags>
   </PropertyGroup>

--- a/src/AprsIsConnection/AprsIsConnection.csproj
+++ b/src/AprsIsConnection/AprsIsConnection.csproj
@@ -6,6 +6,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <PackageId>AprsSharp.AprsIsConnection</PackageId>
+    <Version>1.0.0-alpha.1.0.0</Version>
+    <Authors>Cameron Bielstein</Authors>
+    <Company>Cameron Bielstein</Company>
+    <Description>Library for sending and receiving packets through the Automatic Packet Reporting System Internet Service (APRS-IS)</Description>
+    <PackageTags>ham radio;amateur radio;packet radio;radio;APRS;Automatic Packet Reporting System;Automatic Packet Reporting System Internet System;APRS-IS;</PackageTags>
   </PropertyGroup>
 
 </Project>

--- a/src/AprsParser/AprsParser.csproj
+++ b/src/AprsParser/AprsParser.csproj
@@ -2,6 +2,12 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <PackageId>AprsSharp.AprsParser</PackageId>
+    <Version>1.0.0-alpha.1.0.0</Version>
+    <Authors>Cameron Bielstein</Authors>
+    <Company>Cameron Bielstein</Company>
+    <Description>Library for encoding and decoding packets in the Automatic Packet Reporting System (APRS)</Description>
+    <PackageTags>ham radio;amateur radio;packet radio;radio;APRS;Automatic Packet Reporting System;</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AprsParser/AprsParser.csproj
+++ b/src/AprsParser/AprsParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsParser</PackageId>
-    <Version>1.0.0-alpha.1.0.0</Version>
+    <Version>0.0.0</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>
     <Description>Library for encoding and decoding packets in the Automatic Packet Reporting System (APRS)</Description>

--- a/src/AprsParser/AprsParser.csproj
+++ b/src/AprsParser/AprsParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsParser</PackageId>
-    <Version>0.0.0</Version>
+    <Version>0.1.0</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>
     <Description>Library for encoding and decoding packets in the Automatic Packet Reporting System (APRS)</Description>

--- a/src/AprsParser/AprsParser.csproj
+++ b/src/AprsParser/AprsParser.csproj
@@ -3,9 +3,6 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsParser</PackageId>
-    <Version>0.1.0</Version>
-    <Authors>Cameron Bielstein</Authors>
-    <Company>Cameron Bielstein</Company>
     <Description>Library for encoding and decoding packets in the Automatic Packet Reporting System (APRS)</Description>
     <PackageTags>ham radio;amateur radio;packet radio;radio;APRS;Automatic Packet Reporting System;</PackageTags>
   </PropertyGroup>


### PR DESCRIPTION
## Description

This PR adds the relevant code, documentation, and a new GitHub Action to track two new nuget packages:

* AprsSharp.AprsParser
* AprsSharp.AprsIsClient (our AprsIsConnection library, to be renamed in the future)

This will allow reuse of this code by other code bases and users.

For now, the packages will all have the same version and will change together. They will also be versioned 0.x.y (version 0) until a future date where the public classes and methods can be stabilized.

## Changes

* Add relevant fields for nuget packages to AprsParser and AprsIsConnection
* Add new workflow for publishing nuget packages when a GitHub release is created
* Add documentation

## Validation

* Inspected locally created nuget packages with https://nuget.info to ensure dependencies and properties are correct
* Used local nuget directory to test install and use locally
* Executed new release workflow commands (expect for `dotnet nuget push`) locally to ensure they work
* Will validate after this merges by releasing and checking results
