### PR TITLE
Fix for environment variable in release Actions workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: '6.0.x'
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
       - name: Restore
         run: dotnet restore


### PR DESCRIPTION
## Description

#111 was missing the lines to set the environment variable for the nuget API key. This was caught when creating a release in GitHub. This PR addresses that by properly setting the environment variable based on the GitHub repository secret.

## Changes

* Set environment variable in release workflow based on corresponding GitHub repo secret

## Validation

* Will be validated by running a release
