### PR TITLE
Reuse Package Version for APRS-IS Login

### DIFF
--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -123,6 +123,8 @@
 
         /// <summary>
         /// Uses reflection to get the assembly version as set in the csproj file.
+        /// Currently, this is targeted as the version of AprsSharp.AprsIsClient package, since other projects can use this package.
+        /// This works for now as all the AprsSharp versions are locked together for the time being.
         /// </summary>
         /// <returns>A semver string of the assembly version.</returns>
         private string GetVersion()

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -1,6 +1,7 @@
 ﻿namespace AprsSharp.Connections.AprsIs
 {
     using System;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using AprsSharp.Parsers.Aprs;
@@ -66,7 +67,9 @@
         /// <returns>An async task.</returns>
         public async Task Receive(string callsign, string password, string server, string? filter)
         {
-            string loginMessage = $"user {callsign} pass {password} vers AprsSharp 0.1";
+            string version = GetVersion();
+            string loginMessage = $"user {callsign} pass {password} vers AprsSharp {version}";
+
             if (filter != null)
             {
                 loginMessage += $" filter {filter}";
@@ -116,6 +119,16 @@
                     }
                 }
             });
+        }
+
+        /// <summary>
+        /// Uses reflection to get the assembly version as set in the csproj file.
+        /// </summary>
+        /// <returns>A semver string of the assembly version.</returns>
+        private string GetVersion()
+        {
+            var assemblyInfo = Assembly.GetAssembly(typeof(AprsIsConnection)).GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return assemblyInfo.InformationalVersion;
         }
 
         /// <summary>

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -56,7 +56,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
         {
             IList<string> tcpMessagesReceived = new List<string>();
             bool eventHandled = false;
-            string expectedLoginMessage = $"user N0CALL pass -1 vers AprsSharp 0.1 filter r/50.5039/4.4699/50";
+            string expectedLoginMessage = $"user N0CALL pass -1 vers AprsSharp 0.1.0 filter r/50.5039/4.4699/50";
 
             // Mock underlying TCP connection
             string firstMessage = "# server first message";


### PR DESCRIPTION
## Description

Currently, the AprsSharp version sent to the APRS-IS server is hard-coded in to the connection logic. However, the version used for publishing packages is saved in the package properties (Directory.Build.props sets it across all projects/assemblies).

This changes our code to use reflection to get the assembly version of the AprsIsConnection being used to communicate to the server. Thus eliminating one place to remember to change the version on each release. It should now only be required to update the build properties in the code on each version.

## Changes

* Use reflection to reference assembly version for identifying software version to APRS-IS servers

## Validation

* Updated tests
* Ran AprsSharp CLI and noted the version had updated to the full semver "0.1.0" string
* Temporarily updated just the AprsIsConnection version to "0.1.1". Verified that APRS-IS saw "AprsSharp 0.1.1" while local --version flag said 0.1.0 still. This verifies it's querying the AprsIsConnection assembly version and not the entrypoint assembly.
