### PR TITLE
Add AprsIsConnection.State and State Change Events

### DIFF
--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -57,7 +57,7 @@
         public event HandlePacket? ReceivedPacket;
 
         /// <summary>
-        /// Event raised when the connection changes state.
+        /// Event raised when <see cref="State"/> changes.
         /// </summary>
         public event HandleStateChange? ChangedState;
 

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -139,6 +139,11 @@
                     }
                 });
             }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(ex);
+                throw;
+            }
             finally
             {
                 State = ConnectionState.Disconnected;

--- a/src/AprsIsConnection/ConnectionState.cs
+++ b/src/AprsIsConnection/ConnectionState.cs
@@ -1,0 +1,28 @@
+﻿namespace AprsSharp.Connections.AprsIs
+{
+    /// <summary>
+    /// Tracks the state of an <see cref="AprsIsConnection"/>.
+    /// </summary>
+    public enum ConnectionState
+    {
+        /// <summary>
+        /// The connection has not yet been established.
+        /// </summary>
+        NotConnected,
+
+        /// <summary>
+        /// A connection has been made to the server.
+        /// </summary>
+        Connected,
+
+        /// <summary>
+        /// The server has accepted a login command.
+        /// </summary>
+        LoggedIn,
+
+        /// <summary>
+        /// The connection has been disconnected.
+        /// </summary>
+        Disconnected,
+    }
+}

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -79,7 +79,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", "r/50.5039/4.4699/50");
 
             // Wait to ensure the messages are sent and received
-            WaitForCondition(() => aprsIs.LoggedIn, 1500);
+            WaitForCondition(() => aprsIs.State == ConnectionState.LoggedIn, 1500);
 
             // Assert the callback was triggered and that the expected message was received.
             Assert.True(eventHandled);
@@ -88,7 +88,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             Assert.Contains(loginResponse, tcpMessagesReceived);
 
             // Assert that the login was completed
-            Assert.True(aprsIs.LoggedIn);
+            Assert.Equal(ConnectionState.LoggedIn, aprsIs.State);
 
             // Assert that a connection was started and the login message was sent to the server
             mockTcpConnection.Verify(mock => mock.Connect(


### PR DESCRIPTION
## Description

This switches from a simple "logged in" Boolean flag to tracking state across the full life of the `AprsIsConnection` object. It also adds an event which can be subscribed to for notifications of when that status changes.

This is especially useful for clients who may wish to know when a connection has been achieved, a login complete, or some error has lead to a disconnect and a new connection is required.

## Changes

* Remove `AprsIsConnection.LoggedIn` in favor of `AprsIsConnection.State`
* Introduce `ConnectionState` enum for various states an APRS-IS connection can hold
* Updates and adds tests for validation

## Validation

* Updated tests away from `AprsIsConnection.LoggedIn` to `AprsIsConnection.State`
* Added new tests for disconnected events
* All tests passing
