### PR TITLE
Add log "verbosity" argument and functionality

### DIFF
--- a/src/APRSsharp/APRSsharp.csproj
+++ b/src/APRSsharp/APRSsharp.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20574.7" />
     <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.20574.7" />

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -3,10 +3,10 @@
     using System;
     using System.CommandLine;
     using System.CommandLine.Invocation;
-    using System.IO;
     using System.Threading.Tasks;
     using AprsSharp.Connections.AprsIs;
     using AprsSharp.Parsers.Aprs;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// The public class that will be called when building the console application.
@@ -116,7 +116,14 @@
         public static async Task HandleAprsConnection(string callsign, string password, string server, string filter, IConsole console)
         {
             using TcpConnection tcpConnection = new TcpConnection();
-            AprsIsConnection n = new AprsIsConnection(tcpConnection);
+            using ILoggerFactory loggerFactory = LoggerFactory.Create(config =>
+            {
+                config.ClearProviders();
+                config.AddConsole();
+                config.SetMinimumLevel(LogLevel.Warning);
+            });
+
+            AprsIsConnection n = new AprsIsConnection(tcpConnection, loggerFactory.CreateLogger<AprsIsConnection>());
             n.ReceivedPacket += PrintPacket;
             await n.Receive(callsign, password, server, filter);
         }

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -96,7 +96,7 @@
                     getDefaultValue: () => AprsIsConnection.AprsIsConstants.DefaultFilter,
                     description: "A user filter parsed as a string"),
                 new Option<LogLevel>(
-                    aliases: new string[] { "--logLevel" },
+                    aliases: new string[] { "--verbosity", "-v" },
                     getDefaultValue: () => LogLevel.Warning,
                     description: "Set the verbosity of console logging."),
                 };
@@ -115,16 +115,16 @@
         /// <param name="password"> The user password.</param>
         /// <param name="server"> The specified server to connect.</param>
         /// <param name="filter"> The filter that will be used for receiving the packets.</param>
-        /// <param name="logLevel">The minimum level for an event to be logged to the console.</param>
+        /// <param name="verbosity">The minimum level for an event to be logged to the console.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task HandleAprsConnection(string callsign, string password, string server, string filter, LogLevel logLevel)
+        public static async Task HandleAprsConnection(string callsign, string password, string server, string filter, LogLevel verbosity)
         {
             using TcpConnection tcpConnection = new TcpConnection();
             using ILoggerFactory loggerFactory = LoggerFactory.Create(config =>
             {
-                config.ClearProviders();
-                config.AddConsole();
-                config.SetMinimumLevel(logLevel);
+                config.ClearProviders()
+                    .AddConsole()
+                    .SetMinimumLevel(verbosity);
             });
 
             AprsIsConnection n = new AprsIsConnection(tcpConnection, loggerFactory.CreateLogger<AprsIsConnection>());

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -95,11 +95,15 @@
                     aliases: new string[] { "--filter", "-f" },
                     getDefaultValue: () => AprsIsConnection.AprsIsConstants.DefaultFilter,
                     description: "A user filter parsed as a string"),
+                new Option<LogLevel>(
+                    aliases: new string[] { "--logLevel" },
+                    getDefaultValue: () => LogLevel.Warning,
+                    description: "Set the verbosity of console logging."),
                 };
             rootCommand.Description = "AprsSharp Console App";
 
             // The parameters of the handler method are matched according to the names of the options
-            rootCommand.Handler = CommandHandler.Create<string, string, string, string, IConsole>(HandleAprsConnection);
+            rootCommand.Handler = CommandHandler.Create<string, string, string, string, LogLevel>(HandleAprsConnection);
 
             rootCommand.Invoke(args);
         }
@@ -111,16 +115,16 @@
         /// <param name="password"> The user password.</param>
         /// <param name="server"> The specified server to connect.</param>
         /// <param name="filter"> The filter that will be used for receiving the packets.</param>
-        /// <param name="console"> Flexibility in running in different consoles.</param>
+        /// <param name="logLevel">The minimum level for an event to be logged to the console.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public static async Task HandleAprsConnection(string callsign, string password, string server, string filter, IConsole console)
+        public static async Task HandleAprsConnection(string callsign, string password, string server, string filter, LogLevel logLevel)
         {
             using TcpConnection tcpConnection = new TcpConnection();
             using ILoggerFactory loggerFactory = LoggerFactory.Create(config =>
             {
                 config.ClearProviders();
                 config.AddConsole();
-                config.SetMinimumLevel(LogLevel.Warning);
+                config.SetMinimumLevel(logLevel);
             });
 
             AprsIsConnection n = new AprsIsConnection(tcpConnection, loggerFactory.CreateLogger<AprsIsConnection>());

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -5,6 +5,7 @@
     using System.Threading;
     using System.Threading.Tasks;
     using AprsSharp.Parsers.Aprs;
+    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Delegate for handling a full string from a TCP client.
@@ -31,20 +32,18 @@
     public class AprsIsConnection
     {
         private readonly ITcpConnection tcpConnection;
+        private readonly ILogger<AprsIsConnection>? logger;
         private ConnectionState state = ConnectionState.NotConnected;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AprsIsConnection"/> class.
         /// </summary>
         /// <param name="tcpConnection">An <see cref="ITcpConnection"/> to use for communication.</param>
-        public AprsIsConnection(ITcpConnection tcpConnection)
+        /// <param name="logger">An <see cref="ILogger{AprsIsConnection}"/> for error/debug logging.</param>
+        public AprsIsConnection(ITcpConnection tcpConnection, ILogger<AprsIsConnection>? logger = null)
         {
-            if (tcpConnection == null)
-            {
-                throw new ArgumentNullException(nameof(tcpConnection));
-            }
-
-            this.tcpConnection = tcpConnection;
+            this.tcpConnection = tcpConnection ?? throw new ArgumentNullException(nameof(tcpConnection));
+            this.logger = logger;
         }
 
         /// <summary>
@@ -131,7 +130,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    Console.Error.WriteLine($"Failed to decode packet {received} with error {ex}");
+                                    logger?.LogInformation(ex, "Failed to decode packet {encodedPacked}", received);
                                 }
                             }
                         }
@@ -144,7 +143,7 @@
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(ex);
+                logger?.LogError(ex, "Exception encountered during receive.");
                 throw;
             }
             finally

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -130,7 +130,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    logger.LogInformation(ex, "Failed to decode packet {encodedPacked}", received);
+                                    logger.LogDebug(ex, "Failed to decode packet {encodedPacked}", received);
                                 }
                             }
                         }

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -32,7 +32,7 @@
     public class AprsIsConnection
     {
         private readonly ITcpConnection tcpConnection;
-        private readonly ILogger<AprsIsConnection>? logger;
+        private readonly ILogger<AprsIsConnection> logger;
         private ConnectionState state = ConnectionState.NotConnected;
 
         /// <summary>
@@ -40,7 +40,7 @@
         /// </summary>
         /// <param name="tcpConnection">An <see cref="ITcpConnection"/> to use for communication.</param>
         /// <param name="logger">An <see cref="ILogger{AprsIsConnection}"/> for error/debug logging.</param>
-        public AprsIsConnection(ITcpConnection tcpConnection, ILogger<AprsIsConnection>? logger = null)
+        public AprsIsConnection(ITcpConnection tcpConnection, ILogger<AprsIsConnection> logger)
         {
             this.tcpConnection = tcpConnection ?? throw new ArgumentNullException(nameof(tcpConnection));
             this.logger = logger;
@@ -130,7 +130,7 @@
                                 }
                                 catch (Exception ex)
                                 {
-                                    logger?.LogInformation(ex, "Failed to decode packet {encodedPacked}", received);
+                                    logger.LogInformation(ex, "Failed to decode packet {encodedPacked}", received);
                                 }
                             }
                         }
@@ -143,7 +143,7 @@
             }
             catch (Exception ex)
             {
-                logger?.LogError(ex, "Exception encountered during receive.");
+                logger.LogError(ex, "Exception encountered during receive.");
                 throw;
             }
             finally

--- a/src/AprsIsConnection/AprsIsConnection.csproj
+++ b/src/AprsIsConnection/AprsIsConnection.csproj
@@ -4,6 +4,10 @@
     <ProjectReference Include="..\AprsParser\AprsParser.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+  </ItemGroup>
+
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsIsClient</PackageId>

--- a/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.csproj
+++ b/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="xunit" Version="2.4.0" />

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -5,6 +5,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
     using System.Threading;
     using AprsSharp.Connections.AprsIs;
     using AprsSharp.Parsers.Aprs;
+    using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;
 
@@ -29,7 +30,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString()).Returns(testMessage).Returns(string.Empty);
 
             // Create connection and register a callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -71,7 +72,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                 .Returns(loginResponse);
 
             // Create connection and register callbacks
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -132,7 +133,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             mockTcpConnection.Setup(mock => mock.ReceiveString()).Returns(encodedPacket);
 
             // Create connection and register a callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
             aprsIs.ReceivedPacket += (Packet p) =>
             {
                 receivedPacket = p;
@@ -184,7 +185,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                     .Throws(new Exception("Mock exception connecting!"));
 
             // Create connection and register callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
             aprsIs.ChangedState += (ConnectionState newState) => stateChangesReceived.Add(newState);
             Assert.Equal(ConnectionState.NotConnected, aprsIs.State);
 
@@ -227,7 +228,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                 .Throws(new Exception("Something happened to the connection!"));
 
             // Create connection and register callbacks
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
             aprsIs.ChangedState += (ConnectionState newState) => stateChangesReceived.Add(newState);
 
             // Start receiving

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -5,7 +5,6 @@ namespace AprsSharpUnitTests.Connections.AprsIs
     using System.Threading;
     using AprsSharp.Connections.AprsIs;
     using AprsSharp.Parsers.Aprs;
-    using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;
@@ -240,26 +239,11 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             WaitForCondition(() => aprsIs.State == ConnectionState.Disconnected, 1500);
 
             // Assert the state change event was triggered with the correct state
-
-            Assert.False(true, "Add assertions around logging. I would expect a log error event to be tossed up.");
             Assert.Equal(3, stateChangesReceived.Count);
             Assert.Equal(ConnectionState.Connected, stateChangesReceived[0]);
             Assert.Equal(ConnectionState.LoggedIn, stateChangesReceived[1]);
             Assert.Equal(ConnectionState.Disconnected, stateChangesReceived[2]);
             Assert.Equal(ConnectionState.Disconnected, aprsIs.State);
-        }
-
-        /// <summary>
-        /// Ensures that packets failing decode are successfully logged.
-        /// </summary>
-        /// <param name="logLevel">The <see cref="LogLevel"/> for this test to use.</param>
-        /// <param name="shouldLog">If an event should be logged given the loglevel set.</param>
-        [Theory]
-        [InlineData(LogLevel.Information, true)]
-        [InlineData(LogLevel.Warning, false)]
-        public void LogsFailingDecode(LogLevel logLevel, bool shouldLog)
-        {
-            throw new NotImplementedException();
         }
 
         /// <summary>

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -5,6 +5,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
     using System.Threading;
     using AprsSharp.Connections.AprsIs;
     using AprsSharp.Parsers.Aprs;
+    using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;
@@ -239,11 +240,26 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             WaitForCondition(() => aprsIs.State == ConnectionState.Disconnected, 1500);
 
             // Assert the state change event was triggered with the correct state
+
+            Assert.False(true, "Add assertions around logging. I would expect a log error event to be tossed up.");
             Assert.Equal(3, stateChangesReceived.Count);
             Assert.Equal(ConnectionState.Connected, stateChangesReceived[0]);
             Assert.Equal(ConnectionState.LoggedIn, stateChangesReceived[1]);
             Assert.Equal(ConnectionState.Disconnected, stateChangesReceived[2]);
             Assert.Equal(ConnectionState.Disconnected, aprsIs.State);
+        }
+
+        /// <summary>
+        /// Ensures that packets failing decode are successfully logged.
+        /// </summary>
+        /// <param name="logLevel">The <see cref="LogLevel"/> for this test to use.</param>
+        /// <param name="shouldLog">If an event should be logged given the loglevel set.</param>
+        [Theory]
+        [InlineData(LogLevel.Information, true)]
+        [InlineData(LogLevel.Warning, false)]
+        public void LogsFailingDecode(LogLevel logLevel, bool shouldLog)
+        {
+            throw new NotImplementedException();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

This adds logging verbosity support to APRS#. A new command line argument accepts the ability to change the level of logged events, which allows users to change how much logging they see.

This also sets the default level to exclude packet decode failures, which cleans up output here and allows cleaning up logging when using the nuget package.

Resolves #118.

## Changes

* Switch AprsIsConnection logging from `Console.Error` to `ILogger` and relevant methods
* Pass in an `ILogger` to use for logging events
* Add a command line parameter to set the level of logging

## Validation

* Validated by running locally with various verbosity levels set and observing the output
