### PR TITLE
Added additional nuget package properties

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,8 +8,8 @@
     <Version>0.1.1</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>
-    <PackageProjectUrl>https://github.com/CBielstein/APRSsharp/</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/CBielstein/APRSsharp/</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/CBielstein/APRSsharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/CBielstein/APRSsharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright (c) Cameron Bielstein 2020</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,6 +8,11 @@
     <Version>0.1.1</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>
+    <PackageProjectUrl>https://github.com/CBielstein/APRSsharp/</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/CBielstein/APRSsharp/</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Copyright>Copyright (c) Cameron Bielstein 2020</Copyright>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration.ToLower())' == 'release'">


### PR DESCRIPTION
## Description

Adding additional package properties to add information to the package Nuget.org listings.

These come from the [Microsoft package authoring best practices](https://docs.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices).

## Changes

* Add project URL referencing this repo
* Add repository URL referencing this repo
* Add repository type as git
* Add license type as MIT
* Copyright message

## Validation

* Build and pack work locally
* Used [Nuget Package Explorer](https://nuget.info) to inspect package after local build and observed new properties as expected
