### PR TITLE
Maintain Connection with APRS-IS Server

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -116,7 +116,7 @@
         public static async Task HandleAprsConnection(string callsign, string password, string server, string filter, IConsole console)
         {
             using TcpConnection tcpConnection = new TcpConnection();
-            AprsIsConnection n = new AprsIsConnection(tcpConnection);
+            using AprsIsConnection n = new AprsIsConnection(tcpConnection);
             n.ReceivedPacket += PrintPacket;
             await n.Receive(callsign, password, server, filter);
         }

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -162,6 +162,8 @@
             }
 
             disposed = true;
+
+            timer?.Change(Timeout.Infinite, Timeout.Infinite);
             timer?.Dispose();
         }
 

--- a/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.cs
@@ -19,7 +19,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
         public async void TestDisconnect()
         {
             Mock<ITcpConnection> mockTcpConnection = new Mock<ITcpConnection>();
-            AprsIsConnection connection = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
+            using AprsIsConnection connection = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
 
             Task receiveTask = connection.Receive("callsign", "password", "server", "filter");
 

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -29,7 +29,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString()).Returns(testMessage).Returns(string.Empty);
 
             // Create connection and register a callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -71,7 +71,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                 .Returns(loginResponse);
 
             // Create connection and register callbacks
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -132,7 +132,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             mockTcpConnection.Setup(mock => mock.ReceiveString()).Returns(encodedPacket);
 
             // Create connection and register a callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ReceivedPacket += (Packet p) =>
             {
                 receivedPacket = p;
@@ -184,7 +184,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                     .Throws(new Exception("Mock exception connecting!"));
 
             // Create connection and register callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ChangedState += (ConnectionState newState) => stateChangesReceived.Add(newState);
             Assert.Equal(ConnectionState.NotConnected, aprsIs.State);
 
@@ -227,7 +227,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                 .Throws(new Exception("Something happened to the connection!"));
 
             // Create connection and register callbacks
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ChangedState += (ConnectionState newState) => stateChangesReceived.Add(newState);
 
             // Start receiving

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -41,7 +41,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);
 
             // Wait to ensure the message is received
-            WaitForCondition(() => eventHandled, 750);
+            WaitForCondition(() => eventHandled, 2000);
 
             // Assert the callback was triggered and that the expected message was received.
             Assert.True(eventHandled);


### PR DESCRIPTION
## Description

As described in #122, the APRS-IS servers stop sending data after 48 hours, causing any connected client to stop receiving new packets.

This change adds an event that re-sends the login message every 6 hours to maintain connection and reset the 48hour timeout counter.

This resolves #122.

This uses `System.Threading.Timer` instead of `System.Timers.Timer` to allow multi-threaded use of the underlying `TcpClient` so that receiving is not interrupted.

## Changes

* Add a timer event triggering every 6 hours to message the APRS-IS server
* This makes `AprsIsConnection` disposable, so the required changes were implemented for that as well

## Validation

* Build and tests pass
* Ran locally with a shorter timeframe and verified that APRS-IS servers reset their timeout counter (via APRS-IS server status page) each time a message is sent
* Opting not to put new unit tests on this for now to avoid adding more time-based tests
