### PR TITLE
Manage creation and disposal of `ITcpConnection` in `AprsIsConnection`

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -115,8 +115,7 @@
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task HandleAprsConnection(string callsign, string password, string server, string filter, IConsole console)
         {
-            using TcpConnection tcpConnection = new TcpConnection();
-            AprsIsConnection n = new AprsIsConnection(tcpConnection);
+            using AprsIsConnection n = new AprsIsConnection();
             n.ReceivedPacket += PrintPacket;
             await n.Receive(callsign, password, server, filter);
         }

--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -176,7 +176,7 @@
         }
 
         /// <inheritdoc/>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP007", Justification = "Guarding with boolean flag passed by injector.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("IDisposableAnalyzers.Correctness", "IDISP007", Justification = "Guarding with boolean flag passed to constructor.")]
         public void Dispose()
         {
             if (disposed)

--- a/src/AprsIsConnection/ITcpConnection.cs
+++ b/src/AprsIsConnection/ITcpConnection.cs
@@ -1,9 +1,11 @@
 ﻿namespace AprsSharp.Connections.AprsIs
 {
+    using System;
+
     /// <summary>
     /// Abstracts a TCP connection.
     /// </summary>
-    public interface ITcpConnection
+    public interface ITcpConnection : IDisposable
     {
         /// <summary>
         /// Opens a connection.

--- a/src/AprsIsConnection/TcpConnection.cs
+++ b/src/AprsIsConnection/TcpConnection.cs
@@ -7,7 +7,7 @@
     /// <summary>
     /// Represents a TcpConnection.
     /// </summary>
-    public sealed class TcpConnection : ITcpConnection, IDisposable
+    public sealed class TcpConnection : ITcpConnection
     {
         private readonly TcpClient tcpClient = new TcpClient();
         private NetworkStream? stream;

--- a/test/AprsIsConnectionUnitTests/DisposeUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/DisposeUnitTests.cs
@@ -1,0 +1,36 @@
+namespace AprsSharpUnitTests.Connections.AprsIs
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using AprsSharp.Connections.AprsIs;
+    using AprsSharp.Parsers.Aprs;
+    using Moq;
+    using Xunit;
+
+    /// <summary>
+    /// Unit tests for <see cref="AprsIsConnection.Dispose()"/>.
+    /// </summary>
+    public class DisposeUnitTests
+    {
+        /// <summary>
+        /// Ensures <see cref="AprsIsConnection.Dispose()"/> properly disposes
+        /// the injected <see cref="ITcpConnection"/>.
+        /// </summary>
+        /// <param name="connectionShouldDispose">`true` if the mock <see cref="ITcpConnection"/> should be disposed by the
+        ///     <see cref="AprsIsConnection"/> under test.</param>
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void ProperlyHandlesInjectedTcpConnection(bool connectionShouldDispose)
+        {
+            var mockTcpConnection = new Mock<ITcpConnection>();
+
+            using (AprsIsConnection connection = new AprsIsConnection(mockTcpConnection.Object, connectionShouldDispose))
+            {
+            }
+
+            mockTcpConnection.Verify(mock => mock.Dispose(), connectionShouldDispose ? Times.Once : Times.Never);
+        }
+    }
+}

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -70,7 +70,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                 .Returns(firstMessage)
                 .Returns(loginResponse);
 
-            // Create connection and register a callback
+            // Create connection and register callbacks
             using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -29,7 +29,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString()).Returns(testMessage).Returns(string.Empty);
 
             // Create connection and register a callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -68,7 +68,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
                 .Returns(loginResponse);
 
             // Create connection and register a callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -116,7 +116,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             mockTcpConnection.Setup(mock => mock.ReceiveString()).Returns(encodedPacket);
 
             // Create connection and register a callback
-            var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object);
             aprsIs.ReceivedPacket += (Packet p) =>
             {
                 receivedPacket = p;


### PR DESCRIPTION
## Description

Currently, as unit tests require the ability to inject an `ITcpConnection`, `AprsIsConnection` has a single constructor which requires specifying an `ITcpConnection`.

However, most clients will not need or want to specify their own `ITcpConnection`, so this is overly cumbersome. Instead, this PR changes the incoming `ITcpConnection` to be optional.

To handle ambiguity around if the `ITcpConnection` should be disposed, we follow the pattern laid out by Microsoft's own [HttpClient](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?view=net-6.0), which [allows injection of an `HttpMessageHandler` and specifying whether the HttpClient or the caller should dispose the handler](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient.-ctor?view=net-6.0#system-net-http-httpclient-ctor(system-net-http-httpmessagehandler-system-boolean)).

For most clients of `AprsIsConnection`, they should simply call `new AprsIsConnection()` and allow the object to create and dispose resources. For special cases (tests or advanced resource management), they can call the injection constructor with their `ITcpConnection` and instructions on if it should be disposed.

## Changes

* Add an `AprsIsConnection` constructor overload to allow _not_ passing in an `ITcpConnection`
* Update the `AprsIsConnection(ITcpConnection)` constructor to `AprsIsConnection(ITcpConnection, bool)` to allow specifying who should dispose the `ITcpConnection`
* Make `AprsIsConnection` disposable to facilitate destruction of resources and handle disposes in code and tests
* Move `IDisposable` implementation from `TcpConnection` to the interface `ITcpConnection` to facilitate dispose code
* Added a test to ensure `ITcpConnection.Dispose()` is only called at the right times

## Validation

* Added new test around `AprsIsConnection.Dispose()` logic
* All tests and build passing
