### PR TITLE
Detect TCP server disconnection

### DIFF
--- a/src/AprsIsConnection/AprsIsConnection.cs
+++ b/src/AprsIsConnection/AprsIsConnection.cs
@@ -110,7 +110,7 @@
                 // Receive
                 await Task.Run(() =>
                 {
-                    while (receiving)
+                    while (receiving && tcpConnection.Connected)
                     {
                         string? received = tcpConnection.ReceiveString();
                         if (!string.IsNullOrEmpty(received))

--- a/src/AprsIsConnection/ITcpConnection.cs
+++ b/src/AprsIsConnection/ITcpConnection.cs
@@ -6,6 +6,12 @@
     public interface ITcpConnection
     {
         /// <summary>
+        /// Gets a value indicating whether this connection
+        /// is currently connected to a server.
+        /// </summary>
+        public bool Connected { get; }
+
+        /// <summary>
         /// Opens a connection.
         /// </summary>
         /// <param name="server">Server.</param>

--- a/src/AprsIsConnection/TcpConnection.cs
+++ b/src/AprsIsConnection/TcpConnection.cs
@@ -15,6 +15,9 @@
         private StreamReader? reader;
 
         /// <inheritdoc/>
+        public bool Connected => tcpClient.Connected;
+
+        /// <inheritdoc/>
         public void Connect(string server, int port)
         {
             tcpClient.Connect(server, port);
@@ -66,6 +69,6 @@
         {
             stream?.Close();
             tcpClient.Close();
-      }
+        }
     }
 }

--- a/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.cs
@@ -19,7 +19,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
         public async void TestDisconnect()
         {
             Mock<ITcpConnection> mockTcpConnection = new Mock<ITcpConnection>();
-            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
+            mockTcpConnection.SetupGet(mock => mock.Connected).Returns(true);
             using AprsIsConnection connection = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
 
             Task receiveTask = connection.Receive("callsign", "password", "server", "filter");

--- a/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/AprsIsConnectionUnitTests.cs
@@ -19,6 +19,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
         public async void TestDisconnect()
         {
             Mock<ITcpConnection> mockTcpConnection = new Mock<ITcpConnection>();
+            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
             using AprsIsConnection connection = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
 
             Task receiveTask = connection.Receive("callsign", "password", "server", "filter");

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -28,6 +28,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             string testMessage = "This is a test message";
             var mockTcpConnection = new Mock<ITcpConnection>();
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString()).Returns(testMessage).Returns(string.Empty);
+            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
 
             // Create connection and register a callback
             using var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
@@ -66,6 +67,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             string firstMessage = "# server first message";
             string loginResponse = "# logresp N0CALL unverified, server TEST";
             var mockTcpConnection = new Mock<ITcpConnection>();
+            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
 
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString())
                 .Returns(firstMessage)
@@ -131,6 +133,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             string encodedPacket = @"N0CALL>igate,T2serv:>CN76wv\L Lighthouse!";
             var mockTcpConnection = new Mock<ITcpConnection>();
             mockTcpConnection.Setup(mock => mock.ReceiveString()).Returns(encodedPacket);
+            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
 
             // Create connection and register a callback
             using var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
@@ -221,6 +224,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             string firstMessage = "# server first message";
             string loginResponse = "# logresp N0CALL unverified, server TEST";
             var mockTcpConnection = new Mock<ITcpConnection>();
+            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
 
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString())
                 .Returns(firstMessage)

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -28,7 +28,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             string testMessage = "This is a test message";
             var mockTcpConnection = new Mock<ITcpConnection>();
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString()).Returns(testMessage).Returns(string.Empty);
-            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
+            mockTcpConnection.SetupGet(mock => mock.Connected).Returns(true);
 
             // Create connection and register a callback
             using var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
@@ -133,7 +133,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             string encodedPacket = @"N0CALL>igate,T2serv:>CN76wv\L Lighthouse!";
             var mockTcpConnection = new Mock<ITcpConnection>();
             mockTcpConnection.Setup(mock => mock.ReceiveString()).Returns(encodedPacket);
-            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
+            mockTcpConnection.SetupGet(mock => mock.Connected).Returns(true);
 
             // Create connection and register a callback
             using var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
@@ -224,7 +224,7 @@ namespace AprsSharpUnitTests.Connections.AprsIs
             string firstMessage = "# server first message";
             string loginResponse = "# logresp N0CALL unverified, server TEST";
             var mockTcpConnection = new Mock<ITcpConnection>();
-            mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
+            mockTcpConnection.SetupGet(mock => mock.Connected).Returns(true);
 
             mockTcpConnection.SetupSequence(mock => mock.ReceiveString())
                 .Returns(firstMessage)

--- a/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsConnectionUnitTests/ReceiveUnitTests.cs
@@ -251,6 +251,61 @@ namespace AprsSharpUnitTests.Connections.AprsIs
         }
 
         /// <summary>
+        /// Tests that a server disconnection will set a disconnected state.
+        /// </summary>
+        [Fact]
+        public void ServerDisconnectSetsDisconnectedState()
+        {
+            IList<ConnectionState> stateChangesReceived = new List<ConnectionState>();
+
+            string expectedLoginMessage = $"user N0CALL pass -1 vers AprsSharp 0.1 filter r/50.5039/4.4699/50";
+
+            // Mock underlying TCP connection
+            string firstMessage = "# server first message";
+            string loginResponse = "# logresp N0CALL unverified, server TEST";
+            var mockTcpConnection = new Mock<ITcpConnection>();
+
+            // Return a server message, login response, and packet
+            // then start returning empty (as would happen on disconnect)
+            // and set <see cref="ITcpConnection.Conncted"/> to false
+            mockTcpConnection.SetupSequence(mock => mock.ReceiveString())
+                .Returns(firstMessage)
+                .Returns(loginResponse)
+                .Returns(@"N0CALL>igate,T2serv:>CN76wv\L Lighthouse!")
+                .Returns(string.Empty)
+                .Returns(string.Empty);
+
+            mockTcpConnection.SetupSequence(mock => mock.Connected)
+                .Returns(true)
+                .Returns(true)
+                .Returns(true)
+                .Returns(true)
+                .Returns(false);
+
+            // Create connection and register callbacks
+            using var aprsIs = new AprsIsConnection(mockTcpConnection.Object, NullLogger<AprsIsConnection>.Instance);
+            aprsIs.ChangedState += (ConnectionState newState) => stateChangesReceived.Add(newState);
+
+            // Start receiving
+            Assert.Equal(ConnectionState.NotConnected, aprsIs.State);
+            _ = aprsIs.Receive("N0CALL", "-1", "example.com", "r/50.5039/4.4699/50");
+
+            // Wait to ensure the messages are sent and received
+            WaitForCondition(() => aprsIs.State == ConnectionState.Disconnected, 5000);
+
+            // Assert the state change event was triggered with the correct state
+            Assert.Equal(3, stateChangesReceived.Count);
+            Assert.Equal(ConnectionState.Connected, stateChangesReceived[0]);
+            Assert.Equal(ConnectionState.LoggedIn, stateChangesReceived[1]);
+            Assert.Equal(ConnectionState.Disconnected, stateChangesReceived[2]);
+            Assert.Equal(ConnectionState.Disconnected, aprsIs.State);
+
+            // Assert we only checked connection and receive the correct number of times
+            mockTcpConnection.VerifyGet(mock => mock.Connected, Times.Exactly(5));
+            mockTcpConnection.Verify(mock => mock.ReceiveString(), Times.Exactly(4));
+        }
+
+        /// <summary>
         /// Waits for a specified condition or thows an exception if a time limit is reached.
         /// </summary>
         /// <param name="condition">A function returnig bool to check.</param>


### PR DESCRIPTION
## Description

The current strategy for handling TCP connection interruptions is to rely on an exception on connection disruption. However, if a remote server respectfully closes the connection (as opposed to the connection being interrupted), no exception is generated and the read methods will continue to return empty strings, causing our code to never detect the disconnect and receive empty messages without stopping.

This change pipes through the connection state of the underlying `TcpClient` to check connection on each cycle of the receive loop. This allows the code to detect a disconnection by the server and set the state of the `AprsIsConnection` to disconnected to match.

## Changes

* Pipe through `TcpClient.Connected` check to `ITcpConnection` and `TcpConnection`
* Add a check against `ITcpConnection.Connected` in the receive loop in `AprsIsConnection`
* Add a new test
* Update existing tests

## Validation

* New test covering the disconnection scenario
* Build and tests pass
