### PR TITLE
Correct Typo in Position Regex

### DIFF
--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -32,7 +32,7 @@ namespace AprsSharp.Parsers.Aprs
         ///     Longitude
         ///     Symbol Code.
         /// </summary>
-        public const string PositionLatLongWithSymbols = @"([0-9 \.NW]{8})(.)([0-9 \.EW]{9})(.)";
+        public const string PositionLatLongWithSymbols = @"([0-9 \.NS]{8})(.)([0-9 \.EW]{9})(.)";
 
         /// <summary>
         /// Same as <see cref="MaidenheadGridWithOptionalSymbols"/> but forces full line match.

--- a/test/AprsParserUnitTests/PositionUnitTests.cs
+++ b/test/AprsParserUnitTests/PositionUnitTests.cs
@@ -292,6 +292,7 @@
         [Theory]
         [InlineData(null, '\\', '.', 0, 0)] // defaults
         [InlineData("4903.50N/07201.75W-", '/', '-', 49.0583, -72.0292)] // from APRS spec
+        [InlineData("4903.50S/07201.75E-", '/', '-', -49.0583, 72.0292)] // Ensure south and east work
         public void Decode(
             string? encodedPosition,
             char expectedSymbolTable,


### PR DESCRIPTION
## Description

The regular expression for a position with symbols had a typo specifying latitude in north and west instead of north and south. This PR corrects that typo and adds a test to validate the change.

## Changes

* Fix typo in regex
* Add test

## Validation

* Add test in south and east lat/long to ensure all directions are parsing correctly
* All tests passing