### PR TITLE
Add ConnectedServer Property to AprsIsClient

### DIFF
--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -139,8 +139,8 @@
                             {
                                 if (received.Contains("logresp"))
                                 {
-                                    State = ConnectionState.LoggedIn;
                                     SetConnectedServer(received);
+                                    State = ConnectionState.LoggedIn;
                                  }
 
                                 if (State != ConnectionState.LoggedIn)

--- a/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
+++ b/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
@@ -1,5 +1,8 @@
 namespace AprsSharpUnitTests.Connections.AprsIs
 {
+    using System;
+    using System.Linq;
+    using System.Reflection;
     using System.Threading.Tasks;
     using AprsSharp.Connections.AprsIs;
     using Microsoft.Extensions.Logging.Abstractions;

--- a/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
+++ b/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
@@ -1,8 +1,5 @@
 namespace AprsSharpUnitTests.Connections.AprsIs
 {
-    using System;
-    using System.Linq;
-    using System.Reflection;
     using System.Threading.Tasks;
     using AprsSharp.Connections.AprsIs;
     using Microsoft.Extensions.Logging.Abstractions;

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -130,9 +130,6 @@ namespace AprsSharpUnitTests.Connections.AprsIs
         [InlineData("# logresp", null)]
         public void ReceiveSetConnectedServerProperty(string loginResponse, string? expected)
         {
-            IList<string> tcpMessagesReceived = new List<string>();
-            IList<ConnectionState> stateChangesReceived = new List<ConnectionState>();
-
             // Mock underlying TCP connection
             var mockTcpConnection = new Mock<ITcpConnection>();
             mockTcpConnection.SetupGet(m => m.Connected).Returns(true);
@@ -142,14 +139,6 @@ namespace AprsSharpUnitTests.Connections.AprsIs
 
             // Create connection and register callbacks
             using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
-            aprsIs.ReceivedTcpMessage += (string message) =>
-            {
-                tcpMessagesReceived.Add(message);
-            };
-            aprsIs.ChangedState += (ConnectionState newState) =>
-            {
-                stateChangesReceived.Add(newState);
-            };
 
             // Receive some packets from it.
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", "r/50.5039/4.4699/50");
@@ -159,8 +148,6 @@ namespace AprsSharpUnitTests.Connections.AprsIs
 
             // Assert the ConnectedServer property was set to the correct server or null as appropriate.
             Assert.Equal(expected, aprsIs.ConnectedServer);
-
-            aprsIs.Disconnect();
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

As described in #120, a rotating address is often used to connect to an APRS-IS server; however, the actual connected server is not known to the user.

This change adds parsing to the AprsIsClient class to obtain the connected server and expose it as a property of the class.

## Changes

- Add nullable public property, ConnectedServer, to AprsIsClient
- Add parsing logic via private method to obtain the server name from the connected server's login response and assign to ConnectedServer.  If server name cannot be determined, the property value is set to null.
- Private method also logs server name

## Validation

- Build passes
- Created and passed unit tests
- Ran locally at LogInformation visibility level to confirm server name is captured in property

