### PR TITLE
WeatherInfo parses out comment text 

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -53,6 +53,7 @@
                     Console.WriteLine($"Luminosity: {wi.Luminosity}");
                     Console.WriteLine($"Raw rain: {wi.RainRaw}");
                     Console.WriteLine($"Snow (inches, last 24 hours): {wi.Snow}");
+                    Console.WriteLine($"Weather Comment: {wi.Comment}");
                 }
             }
             else if (p.InfoField is StatusInfo si)

--- a/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
@@ -47,7 +47,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         [InlineData(
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b09900wRSW",
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b09900wRSW",
-            "220/004g005t077r000p000P000h50b09900wRSW",
+            "wRSW",
             220,
             4,
             5,
@@ -61,7 +61,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         [InlineData( // Luminosity 10
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b09900L010wRSW",
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b09900L010wRSW",
-            "220/004g005t077r000p000P000h50b09900L010wRSW",
+            "wRSW",
             220,
             4,
             5,
@@ -75,7 +75,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         [InlineData( // Luminosity 1010
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b09900l010wRSW",
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b09900l010wRSW",
-            "220/004g005t077r000p000P000h50b09900l010wRSW",
+            "wRSW",
             220,
             4,
             5,
@@ -89,7 +89,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         [InlineData(
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b.....wRSW",
             "!4903.50N/07201.75W_220/004g005t077r000p000P000h50b.....wRSW",
-            "220/004g005t077r000p000P000h50b.....wRSW",
+            "wRSW",
             220,
             4,
             5,
@@ -103,7 +103,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         [InlineData(
             "@092345z4903.50N/07201.75W_220/004g005t-07r000p000P000h50b09900wRSW",
             "@092345z4903.50N/07201.75W_220/004g005t-07r000p000P000h50b09900wRSW",
-            "220/004g005t-07r000p000P000h50b09900wRSW",
+            "wRSW",
             220,
             4,
             5,
@@ -117,7 +117,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
         [InlineData(
             "@092345z4903.50N/07201.75W_090/000g000t066r000p000...dUII",
             "@092345z4903.50N/07201.75W_090/000g000t066r000p000P...h..b.....dUII",
-            "090/000g000t066r000p000...dUII",
+            "...dUII",
             90,
             0,
             0,
@@ -127,6 +127,38 @@ namespace AprsSharpUnitTests.Parsers.Aprs
             null,
             null,
             "dUII",
+            PacketType.PositionWithTimestampWithMessaging)]
+
+        // Tests if there is a measurement in the comment.  We preserve it in the comment and treat as a measurement.
+        [InlineData(
+            "@092345z4903.50N/07201.75W_090/000g000t066r000p000...dUIIL878",
+            "@092345z4903.50N/07201.75W_090/000g000t066r000p000P...h..b.....L878...dUIIL878",
+            "...dUIIL878",
+            90,
+            0,
+            0,
+            66,
+            null,
+            null,
+            null,
+            878,
+            "...dUIIL878",
+            PacketType.PositionWithTimestampWithMessaging)]
+
+        // Tests if the measurement is in the data AND in the comment.  Assumes first occurrence is the measurement.
+        [InlineData(
+            "@092345z4903.50N/07201.75W_090/000g000t066r000p000L555dUIIL878",
+            "@092345z4903.50N/07201.75W_090/000g000t066r000p000P...h..b.....L555dUIIL878",
+            "dUIIL878",
+            90,
+            0,
+            0,
+            66,
+            null,
+            null,
+            null,
+            555,
+            "dUIIL878",
             PacketType.PositionWithTimestampWithMessaging)]
         public void TestCompleteWeatherReport(
             string encodedInfoField,
@@ -219,7 +251,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
 
             AssertWeatherInfo(
                 p.InfoField as WeatherInfo,
-                "180/010g015t068r001p011P010h99b09901l010#010s050 Testing WX packet.",
+                " Testing WX packet.",
                 false,
                 testTimestamp,
                 testPosition,


### PR DESCRIPTION
## Description

Trims the encoded weather measurements from the `WeatherInfo` info field object.  Places the remaining "user" comment into the `Comment` property of the `WeatherInfo` object. 

#105 
## Changes

*Add `Comment` property to `WeatherInfo` class.  `PositionInfo` base class will still hold the untrimmed comment.
*Add logic in `WeatherInfo` to determine the consecutive portion of the comment which contains weather measurement data and strips that out of the comment.  Weather measurements inside the comment will remain in the user comment and be evaluated as measurements.
*Update `PrintPacket` to display weather user comment
*Modify and create unit tests

## Validation

*Build passes
*Passed unit tests for encode/decode
*Ran with live data and confirmed user comment captured as desired
