### PR TITLE
Update actions versions for node16 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: DotnetVersion
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
           

--- a/.github/workflows/markdown.yml
+++ b/.github/workflows/markdown.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Lint
         uses: nosborn/github-action-markdown-cli@v1.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: DotnetVersion
-        uses: actions/setup-dotnet@v1
+        uses: actions/setup-dotnet@v3
         with:
           dotnet-version: '6.0.x'
 


### PR DESCRIPTION
## Description

Resolves #139 by updating actions versions of actions using older node runtime versions.

## Changes

* Updates actions/checkout from v2 to v3
* Updates actions/setup-dotnet from v1 to v3

## Validation

* Validated as part of this PR
