### PR TITLE
Messages

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -67,11 +67,11 @@
                 Console.WriteLine($"    Position: {mbi.Position.EncodeGridsquare(4, false)}");
                 Console.WriteLine($"    Comment: {mbi.Comment}");
             }
-            else if (p.InfoField is Message m)
+            else if (p.InfoField is MessageInfo mi)
             {
-                Console.WriteLine($"    To: {m.Addressee}");
-                Console.WriteLine($"    Message: {m.Content}");
-                Console.WriteLine($"    ID: {m.MessageId}");
+                Console.WriteLine($"    To: {mi.Addressee}");
+                Console.WriteLine($"    Message: {mi.Content}");
+                Console.WriteLine($"    ID: {mi.Id}");
             }
 
             Console.WriteLine();

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -67,6 +67,12 @@
                 Console.WriteLine($"    Position: {mbi.Position.EncodeGridsquare(4, false)}");
                 Console.WriteLine($"    Comment: {mbi.Comment}");
             }
+            else if (p.InfoField is Message m)
+            {
+                Console.WriteLine($"    To: {m.Addressee}");
+                Console.WriteLine($"    Message: {m.Content}");
+                Console.WriteLine($"    ID: {m.MessageId}");
+            }
 
             Console.WriteLine();
         }

--- a/src/AprsParser/InfoField/InfoField.cs
+++ b/src/AprsParser/InfoField/InfoField.cs
@@ -83,6 +83,9 @@
                 case PacketType.MaidenheadGridLocatorBeacon:
                     return new MaidenheadBeaconInfo(encodedInfoField);
 
+                case PacketType.Message:
+                    return new MessageInfo(encodedInfoField);
+
                 default:
                     throw new NotImplementedException($"FromString not implemented for info field type {type}");
             }

--- a/src/AprsParser/InfoField/Message.cs
+++ b/src/AprsParser/InfoField/Message.cs
@@ -32,10 +32,10 @@ namespace AprsSharp.Parsers.Aprs
                 throw new ArgumentException($"Packet encoding not of type {nameof(PacketType.Message)}. Type was {Type}", nameof(encodedInfoField));
             }
 
-            Match match = Regex.Match(encodedInfoField, RegexStrings.Message);
+            Match match = Regex.Match(encodedInfoField, RegexStrings.MessageWithId);
             if (match.Success)
             {
-                match.AssertSuccess(PacketType.Status, nameof(encodedInfoField));
+                match.AssertSuccess(PacketType.Message, nameof(encodedInfoField));
 
                 Addressee = match.Groups[1].Value.TrimEnd();
 
@@ -44,7 +44,7 @@ namespace AprsSharp.Parsers.Aprs
                     Content = match.Groups[2].Value;
                 }
 
-                if (match.Groups[3].Success)
+                if (match.Groups[4].Success)
                 {
                     MessageId = match.Groups[3].Value;
                 }
@@ -56,7 +56,7 @@ namespace AprsSharp.Parsers.Aprs
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="StatusInfo"/> class.
+        /// Initializes a new instance of the <see cref="Message"/> class.
         /// </summary>
         /// <param name="addressee">The station to which this message is addressed.</param>
         /// <param name="content">The content of the message, optional.</param>

--- a/src/AprsParser/InfoField/Message.cs
+++ b/src/AprsParser/InfoField/Message.cs
@@ -1,0 +1,152 @@
+namespace AprsSharp.Parsers.Aprs
+{
+    using System;
+    using System.Text;
+    using System.Text.RegularExpressions;
+    using AprsSharp.Parsers.Aprs.Extensions;
+
+    /// <summary>
+    /// Represents an info field for packet type <see cref="PacketType.Message"/>.
+    /// </summary>
+    public class Message : InfoField
+    {
+        /// <summary>
+        /// The list of characters which may not be used in the message content.
+        /// </summary>
+        private static readonly char[] ContentDisallowedChars = { '|', '~', '{' };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Message"/> class.
+        /// </summary>
+        /// <param name="encodedInfoField">A string encoding of a <see cref="Message"/>.</param>
+        public Message(string encodedInfoField)
+            : base(encodedInfoField)
+        {
+            if (string.IsNullOrWhiteSpace(encodedInfoField))
+            {
+                throw new ArgumentNullException(nameof(encodedInfoField));
+            }
+
+            if (Type != PacketType.Message)
+            {
+                throw new ArgumentException($"Packet encoding not of type {nameof(PacketType.Message)}. Type was {Type}", nameof(encodedInfoField));
+            }
+
+            Match match = Regex.Match(encodedInfoField, RegexStrings.Message);
+            if (match.Success)
+            {
+                match.AssertSuccess(PacketType.Status, nameof(encodedInfoField));
+
+                Addressee = match.Groups[1].Value.TrimEnd();
+
+                if (match.Groups[2].Success)
+                {
+                    Content = match.Groups[2].Value;
+                }
+
+                if (match.Groups[3].Success)
+                {
+                    MessageId = match.Groups[3].Value;
+                }
+            }
+            else
+            {
+                throw new ArgumentException("Did not match RegexStrings.Message");
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StatusInfo"/> class.
+        /// </summary>
+        /// <param name="addressee">The station to which this message is addressed.</param>
+        /// <param name="content">The content of the message, optional.</param>
+        /// <param name="messageId">An ID for the message, optional. If supplied, this requests acknowledgement.</param>
+        public Message(string addressee, string? content, string? messageId)
+            : base(PacketType.Message)
+        {
+            if (string.IsNullOrEmpty(addressee))
+            {
+                throw new ArgumentNullException(nameof(addressee));
+            }
+            else if (addressee.Length > 9)
+            {
+                throw new ArgumentException("Addressee string may have maximum length 9", nameof(addressee));
+            }
+
+            if (messageId != null)
+            {
+                if (messageId.Length == 0 || messageId.Length > 5)
+                {
+                    throw new ArgumentException("If provided, ID must be of length (0,5]", nameof(messageId));
+                }
+                else if (!Regex.IsMatch(content, RegexStrings.Alphanumeric))
+                {
+                    throw new ArgumentException("If provided, ID must be only alphanumeric", nameof(messageId));
+                }
+            }
+
+            if (content != null)
+            {
+                if (content.Length > 67)
+                {
+                    throw new ArgumentException("Message content must be 67 characters or less", nameof(content));
+                }
+                else if (content.IndexOfAny(ContentDisallowedChars) != -1)
+                {
+                    throw new ArgumentException("Message content may not include `|`, `~`, or `{`", nameof(content));
+                }
+            }
+
+            Addressee = addressee;
+            Content = content;
+            MessageId = messageId;
+        }
+
+        /// <summary>
+        /// Gets the addressee of the message.
+        /// </summary>
+        public string Addressee { get; }
+
+        /// <summary>
+        /// Gets the message content.
+        /// </summary>
+        public string? Content { get; }
+
+        /// <summary>
+        /// Gets the message ID, which uniquely identifies a message
+        /// between a sender and a receiver.
+        /// </summary>
+        public string? MessageId { get; }
+
+        /// <inheritdoc/>
+        public override string Encode()
+        {
+            StringBuilder encoded = new StringBuilder();
+
+            encoded.Append($":{Addressee}");
+
+            // Encoded addressee must have length 9 and is padded with
+            // spaces if too short
+            if (Addressee.Length < 9)
+            {
+                var spacesToAdd = 9 - Addressee.Length;
+                for (var i = 0; i < spacesToAdd; ++i)
+                {
+                    encoded.Append(' ');
+                }
+            }
+
+            encoded.Append(':');
+
+            encoded.Append(Content ?? String.Empty);
+
+            if (MessageId != null)
+            {
+                encoded.Append('{');
+                encoded.Append(MessageId);
+            }
+
+            return encoded.ToString();
+        }
+    }
+}

--- a/src/AprsParser/InfoField/MessageInfo.cs
+++ b/src/AprsParser/InfoField/MessageInfo.cs
@@ -46,7 +46,7 @@ namespace AprsSharp.Parsers.Aprs
 
                 if (match.Groups[4].Success)
                 {
-                    Id = match.Groups[3].Value;
+                    Id = match.Groups[4].Value;
                 }
             }
             else

--- a/src/AprsParser/InfoField/MessageInfo.cs
+++ b/src/AprsParser/InfoField/MessageInfo.cs
@@ -79,7 +79,7 @@ namespace AprsSharp.Parsers.Aprs
                 {
                     throw new ArgumentException("If provided, ID must be of length (0,5]", nameof(messageId));
                 }
-                else if (!Regex.IsMatch(content, RegexStrings.Alphanumeric))
+                else if (!Regex.IsMatch(messageId, RegexStrings.Alphanumeric))
                 {
                     throw new ArgumentException("If provided, ID must be only alphanumeric", nameof(messageId));
                 }

--- a/src/AprsParser/InfoField/MessageInfo.cs
+++ b/src/AprsParser/InfoField/MessageInfo.cs
@@ -8,7 +8,7 @@ namespace AprsSharp.Parsers.Aprs
     /// <summary>
     /// Represents an info field for packet type <see cref="PacketType.Message"/>.
     /// </summary>
-    public class Message : InfoField
+    public class MessageInfo : InfoField
     {
         /// <summary>
         /// The list of characters which may not be used in the message content.
@@ -16,10 +16,10 @@ namespace AprsSharp.Parsers.Aprs
         private static readonly char[] ContentDisallowedChars = { '|', '~', '{' };
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Message"/> class.
+        /// Initializes a new instance of the <see cref="MessageInfo"/> class.
         /// </summary>
-        /// <param name="encodedInfoField">A string encoding of a <see cref="Message"/>.</param>
-        public Message(string encodedInfoField)
+        /// <param name="encodedInfoField">A string encoding of a <see cref="MessageInfo"/>.</param>
+        public MessageInfo(string encodedInfoField)
             : base(encodedInfoField)
         {
             if (string.IsNullOrWhiteSpace(encodedInfoField))
@@ -46,7 +46,7 @@ namespace AprsSharp.Parsers.Aprs
 
                 if (match.Groups[4].Success)
                 {
-                    MessageId = match.Groups[3].Value;
+                    Id = match.Groups[3].Value;
                 }
             }
             else
@@ -56,12 +56,12 @@ namespace AprsSharp.Parsers.Aprs
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Message"/> class.
+        /// Initializes a new instance of the <see cref="MessageInfo"/> class.
         /// </summary>
         /// <param name="addressee">The station to which this message is addressed.</param>
         /// <param name="content">The content of the message, optional.</param>
         /// <param name="messageId">An ID for the message, optional. If supplied, this requests acknowledgement.</param>
-        public Message(string addressee, string? content, string? messageId)
+        public MessageInfo(string addressee, string? content, string? messageId)
             : base(PacketType.Message)
         {
             if (string.IsNullOrEmpty(addressee))
@@ -99,7 +99,7 @@ namespace AprsSharp.Parsers.Aprs
 
             Addressee = addressee;
             Content = content;
-            MessageId = messageId;
+            Id = messageId;
         }
 
         /// <summary>
@@ -116,7 +116,7 @@ namespace AprsSharp.Parsers.Aprs
         /// Gets the message ID, which uniquely identifies a message
         /// between a sender and a receiver.
         /// </summary>
-        public string? MessageId { get; }
+        public string? Id { get; }
 
         /// <inheritdoc/>
         public override string Encode()
@@ -138,12 +138,12 @@ namespace AprsSharp.Parsers.Aprs
 
             encoded.Append(':');
 
-            encoded.Append(Content ?? String.Empty);
+            encoded.Append(Content ?? string.Empty);
 
-            if (MessageId != null)
+            if (Id != null)
             {
                 encoded.Append('{');
-                encoded.Append(MessageId);
+                encoded.Append(Id);
             }
 
             return encoded.ToString();

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -102,7 +102,7 @@ namespace AprsSharp.Parsers.Aprs
         ///     Addressee
         ///     Content (optional)
         ///     MessageIdTag (includes `{`)
-        ///     MessageId (excludes `{`)
+        ///     MessageId (excludes `{`).
         /// </summary>
         public const string MessageWithId = @"^:(.{9}):([^:~{]+)({([a-zA-Z0-9]{1,5}))?$";
     }

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -89,5 +89,10 @@ namespace AprsSharp.Parsers.Aprs
         ///     Info field.
         /// </summary>
         public const string Tnc2Packet = @"^([^>]+)>([^:]+):(.+)$";
+
+        /// <summary>
+        /// Validates that a given string is only alphanumeric characters in a single line.
+        /// </summary>
+        public const string Alphanumeric = @"^[a-zA-Z0-9]+$";
     }
 }

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -94,5 +94,16 @@ namespace AprsSharp.Parsers.Aprs
         /// Validates that a given string is only alphanumeric characters in a single line.
         /// </summary>
         public const string Alphanumeric = @"^[a-zA-Z0-9]+$";
+
+        /// <summary>
+        /// Matches a Message info field.
+        /// N matches:
+        ///     Full
+        ///     Addressee
+        ///     Content (optional)
+        ///     MessageIdTag (includes `{`)
+        ///     MessageId (excludes `{`)
+        /// </summary>
+        public const string MessageWithId = @"^:(.{9}):([^:~{]+)({([a-zA-Z0-9]{1,5}))?$";
     }
 }

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -104,6 +104,6 @@ namespace AprsSharp.Parsers.Aprs
         ///     MessageIdTag (includes `{`)
         ///     MessageId (excludes `{`).
         /// </summary>
-        public const string MessageWithId = @"^:(.{9}):([^:~{]+)({([a-zA-Z0-9]{1,5}))?$";
+        public const string MessageWithId = @"^:(.{9}):([^:~{]+)?({([a-zA-Z0-9]{1,5}))?$";
     }
 }

--- a/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
@@ -1,0 +1,93 @@
+namespace AprsSharpUnitTests.Parsers.Aprs
+{
+    using System;
+    using System.Linq;
+    using AprsSharp.Parsers.Aprs;
+    using GeoCoordinatePortable;
+    using Xunit;
+
+    /// <summary>
+    /// Tests code in the <see cref="MessageInfo"/> class related to encode/decode of position reports.
+    /// </summary>
+    public class MessageInfoUnitTests
+    {
+        /// <summary>
+        /// Verifies decoding and re-encoding a full status packet in TNC2 format.
+        /// </summary>
+        [Fact]
+        public void TestRoundTrip()
+        {
+            string encoded = "N0CALL>WIDE2-2:>IO91SX/G My house";
+            Packet p = new Packet(encoded);
+
+            Assert.Equal("N0CALL", p.Sender);
+            Assert.Equal("WIDE2-2", p.Path.Single());
+            Assert.True((p.ReceivedTime - DateTime.UtcNow) < TimeSpan.FromMinutes(1));
+            Assert.Equal(PacketType.Status, p.InfoField.Type);
+
+            if (p.InfoField is StatusInfo si)
+            {
+                // Coordinates not precise when coming from gridhead
+                double latitude = si?.Position?.Coordinates.Latitude ?? throw new Exception("Latitude should not be null");
+                double longitude = si?.Position?.Coordinates.Longitude ?? throw new Exception("Longitude should not be null");
+                Assert.Equal(51.98, Math.Round(latitude, 2));
+                Assert.Equal(-0.46, Math.Round(longitude, 2));
+                Assert.Equal("IO91SX", si?.Position?.EncodeGridsquare(6, false));
+                Assert.Equal('/', si?.Position?.SymbolTableIdentifier);
+                Assert.Equal('G', si?.Position?.SymbolCode);
+                Assert.Equal("My house", si?.Comment);
+            }
+            else
+            {
+                Assert.IsType<StatusInfo>(p.InfoField);
+            }
+
+            Assert.Equal(encoded, p.Encode());
+        }
+
+        /// <summary>
+        /// Tests decoding a message info field based on the APRS spec.
+        /// </summary>
+        /// <param name="informationField">Information field for decode.</param>
+        /// <param name="expectedAddressee">Expected decoded addressee.</param>
+        /// <param name="expectedContent">Expected decoded content.</param>
+        /// <param name="expectedId">Expected decoded message ID.</param>
+        [Theory]
+        [InlineData(":WU2Z     :Testing", "WU2Z", "Testing", null)]
+        [InlineData(":WU2Z     :Testing{003", "WU2Z", "Testing", "003")]
+        [InlineData(":EMAIL    :msproul@ap.org Test email", "EMAIL", "msproul@ap.org Test email", null)]
+        public void DecodeMessageFormat(
+            string informationField,
+            string expectedAddressee,
+            string expectedContent,
+            string? expectedId)
+        {
+            MessageInfo mi = new MessageInfo(informationField);
+
+            Assert.Equal(expectedAddressee, mi.Addressee);
+            Assert.Equal(expectedContent, mi.Content);
+            Assert.Equal(expectedId, mi.Id);
+        }
+
+        /// <summary>
+        /// Tests encoding a message info field based on the APRS spec.
+        /// </summary>
+        /// <param name="addressee">Expected decoded addressee.</param>
+        /// <param name="content">Expected decoded content.</param>
+        /// <param name="id">Expected decoded message ID.</param>
+        /// <param name="expectedEncoding">Information field for decode.</param>
+        [Theory]
+        [InlineData("WU2Z", "Testing", null, ":WU2Z     :Testing")]
+        [InlineData("WU2Z", "Testing", "003", ":WU2Z     :Testing{003")]
+        [InlineData("EMAIL", "msproul@ap.org Test email", null, ":EMAIL    :msproul@ap.org Test email")]
+        public void EncodeMessageFormat(
+            string addressee,
+            string content,
+            string? id,
+            string expectedEncoding)
+        {
+            MessageInfo mi = new MessageInfo(addressee, content, id);
+            Assert.Equal(expectedEncoding, mi.Encode());
+        }
+    }
+}


### PR DESCRIPTION
## Description

Implement message type info field for encoding and decoding.

## Changes

* Introduces `MessageInfo` type
* Adds required new regex strings
* Adds tests for `MessageInfo`
* Adds display of `MessageInfo` type to APRSsharp.exe

## Validation

* Tests pass
* Linting is clean
* Can view messages in APRSsharp.exe with `-f t/m`