### PR TITLE
Status no maiden

### DIFF
--- a/src/AprsParser/InfoField/StatusInfo.cs
+++ b/src/AprsParser/InfoField/StatusInfo.cs
@@ -67,7 +67,7 @@ namespace AprsSharp.Parsers.Aprs
         /// </summary>
         /// <param name="timestamp">An optional timestamp.</param>
         /// <param name="comment">An optional comment.</param>
-        public StatusInfo(Timestamp timestamp, string? comment)
+        public StatusInfo(Timestamp? timestamp, string? comment)
             : this(timestamp, null, comment)
         {
         }

--- a/src/AprsParser/InfoField/StatusInfo.cs
+++ b/src/AprsParser/InfoField/StatusInfo.cs
@@ -32,8 +32,9 @@ namespace AprsSharp.Parsers.Aprs
                 throw new ArgumentException($"Packet encoding not of type {nameof(PacketType.Status)}. Type was {Type}", nameof(encodedInfoField));
             }
 
+            // First look with maidenhead
             Match match = Regex.Match(encodedInfoField, RegexStrings.StatusWithMaidenheadAndComment);
-            if (match.Success)
+            if (match.Success && Position.IsValidMaidenhead(match.Groups[1].Value))
             {
                 match.AssertSuccess(PacketType.Status, nameof(encodedInfoField));
 
@@ -44,12 +45,30 @@ namespace AprsSharp.Parsers.Aprs
                 {
                     Comment = match.Groups[4].Value;
                 }
+
+                return;
             }
-            else
+
+            // Next try without maidenhead
+            match = Regex.Match(encodedInfoField, RegexStrings.StatusWithOptionalTimestampAndComment);
+            if (match.Success)
             {
-                // TODO Issue #88
-                throw new NotImplementedException("Status report without maidenhead not yet implemented.Tracked by issue #88.");
+                match.AssertSuccess(PacketType.Status, nameof(encodedInfoField));
+
+                if (match.Groups[1].Success)
+                {
+                    Timestamp = new Timestamp(match.Groups[1].Value);
+                }
+
+                if (match.Groups[2].Success)
+                {
+                    Comment = match.Groups[2].Value;
+                }
+
+                return;
             }
+
+            throw new ArgumentException("Packet did not match any implemented versions of status info.");
         }
 
         /// <summary>
@@ -144,6 +163,8 @@ namespace AprsSharp.Parsers.Aprs
         {
             StringBuilder encoded = new StringBuilder();
 
+            encoded.Append(Type.ToChar());
+
             if (Position != null)
             {
                 if (Timestamp != null)
@@ -151,7 +172,6 @@ namespace AprsSharp.Parsers.Aprs
                     throw new ArgumentException($"{nameof(Timestamp)} may not be specified if a position is given.");
                 }
 
-                encoded.Append(Type.ToChar());
                 encoded.Append(Position.EncodeGridsquare(6, true));
 
                 if (!string.IsNullOrEmpty(Comment))
@@ -161,8 +181,15 @@ namespace AprsSharp.Parsers.Aprs
             }
             else
             {
-                // TODO Issue #88
-                throw new NotImplementedException("Status report without maidenhead not yet implemented.Tracked by issue #88.");
+                if (Timestamp != null)
+                {
+                    encoded.Append(Timestamp.Encode(TimestampType.DHMz));
+                }
+
+                if (!string.IsNullOrEmpty(Comment))
+                {
+                    encoded.Append(Comment);
+                }
             }
 
             return encoded.ToString();

--- a/src/AprsParser/Position.cs
+++ b/src/AprsParser/Position.cs
@@ -138,6 +138,25 @@
         }
 
         /// <summary>
+        /// Returns true if a given string is a valid maidenhead gridsquare format.
+        /// </summary>
+        /// <param name="gridsquare">A gridsquare string to test.</param>
+        /// <returns>True if it can be decoded, else false.</returns>
+        public static bool IsValidMaidenhead(string gridsquare)
+        {
+            try
+            {
+                var position = new Position();
+                position.DecodeMaidenhead(gridsquare);
+                return true;
+            }
+            catch (ArgumentException)
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Takes an encoded APRS coordinate string and uses it to initialize to <see cref="GeoCoordinate"/>.
         /// </summary>
         /// <param name="coords">A string of APRS encoded coordinates.</param>

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -53,6 +53,15 @@ namespace AprsSharp.Parsers.Aprs
         public const string StatusWithMaidenheadAndComment = $@"^>({MaidenheadGridWithSymbols}) ?(.+)?$";
 
         /// <summary>
+        /// Matches a Status info field without Maidenhead grid. Allows optional timestamp and comment.
+        /// Three matches:
+        ///     Full
+        ///     Timestamp
+        ///     Comment.
+        /// </summary>
+        public const string StatusWithOptionalTimestampAndComment = @"^>([0-9]{6}z)?(([^|~\n])+)?$";
+
+        /// <summary>
         /// Matches a PositionWithoutTimestamp info field.
         /// Seven mathces:
         ///     Full

--- a/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
@@ -101,5 +101,56 @@ namespace AprsSharpUnitTests.Parsers.Aprs
             StatusInfo si = new StatusInfo(p, comment);
             Assert.Equal(expectedEncoding, si.Encode());
         }
+
+        /// <summary>
+        /// Tests decoding a status report without Maidenhead info field based on the APRS spec.
+        /// </summary>
+        /// <param name="informationField">Information field for decode.</param>
+        /// <param name="expectedTime">Expected decoded timestamp.</param>
+        /// <param name="expectedComment">Expected decoded comment.</param>
+        [Theory]
+        [InlineData(">Net Control Center", null, "Net Control Center")]
+        [InlineData(">092345zNet Control Center", "092345z", "Net Control Center")]
+        public void DecodeStatusReportFormatWithoutMaidenhead(
+            string informationField,
+            string? expectedTime,
+            string? expectedComment)
+        {
+            StatusInfo si = new StatusInfo(informationField);
+
+            Assert.Null(si.Position);
+            Assert.Equal(expectedComment, si.Comment);
+
+            if (expectedTime != null)
+            {
+                var expectedTimestamp = new Timestamp(expectedTime);
+                Assert.NotNull(si.Timestamp);
+                Assert.Equal(expectedTimestamp.DecodedType, si.Timestamp!.DecodedType);
+                Assert.Equal(expectedTimestamp.DateTime, si.Timestamp!.DateTime);
+            }
+            else
+            {
+                Assert.Null(si.Timestamp);
+            }
+        }
+
+        /// <summary>
+        /// Tests encoding a status report without Maidenhead info field based on the APRS spec.
+        /// </summary>
+        /// <param name="time">Time to encode.</param>
+        /// <param name="comment">Comment to encode.</param>
+        /// <param name="expectedEncoding">Expected encoding.</param>
+        [Theory]
+        [InlineData(null, "Net Control Center", ">Net Control Center")]
+        [InlineData("092345z", "Net Control Center", ">092345zNet Control Center")]
+        public void EncodeStatusReportFormatWithoutMaidenhead(
+            string? time,
+            string comment,
+            string expectedEncoding)
+        {
+            Timestamp? timestamp = time == null ? null : new Timestamp(time);
+            StatusInfo si = new StatusInfo(timestamp, comment);
+            Assert.Equal(expectedEncoding, si.Encode());
+        }
     }
 }


### PR DESCRIPTION
## Description

Implements encode and decode of Status info fields without a position.
Resolves #88.

## Changes

* Implements encode and decode of non-maidenhead status reports
* Adds required helpers and regex strings
* Expands tests for new scenarios

## Validation

* Tests and lint are successful
* Able to run APRSsharp.exe and view status reports without position both with and without timestamp using `-f t/s`
