### PR TITLE
Rename `Packet.Encode` to `Packet.EncodeTnc2`

### DIFF
--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -66,10 +66,10 @@
         public InfoField InfoField { get; }
 
         /// <summary>
-        /// Encodes an APRS packet to a string.
+        /// Encodes an APRS packet as a string in TNC2 format.
         /// </summary>
-        /// <returns>String representation of the packet.</returns>
-        public virtual string Encode()
+        /// <returns>String of packet in TNC2 format.</returns>
+        public string EncodeTnc2()
         {
             return $"{Sender}>{string.Join(',', Path)}:{InfoField.Encode()}";
         }

--- a/test/AprsParserUnitTests/InfoField/MaidenheadBeaconInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/MaidenheadBeaconInfoUnitTests.cs
@@ -47,7 +47,7 @@
                 Assert.IsType<MaidenheadBeaconInfo>(p.InfoField);
             }
 
-            Assert.Equal(encoded, p.Encode());
+            Assert.Equal(encoded, p.EncodeTnc2());
         }
 
         /// <summary>

--- a/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
@@ -36,7 +36,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
                 Assert.IsType<MessageInfo>(p.InfoField);
             }
 
-            Assert.Equal(encoded, p.Encode());
+            Assert.Equal(encoded, p.EncodeTnc2());
         }
 
         /// <summary>

--- a/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
@@ -48,7 +48,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
                 Assert.IsType<PositionInfo>(p.InfoField);
             }
 
-            Assert.Equal(encoded, p.Encode());
+            Assert.Equal(encoded, p.EncodeTnc2());
         }
 
         /// <summary>

--- a/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
@@ -42,7 +42,7 @@ namespace AprsSharpUnitTests.Parsers.Aprs
                 Assert.IsType<StatusInfo>(p.InfoField);
             }
 
-            Assert.Equal(encoded, p.Encode());
+            Assert.Equal(encoded, p.EncodeTnc2());
         }
 
         /// <summary>

--- a/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
@@ -290,8 +290,8 @@ namespace AprsSharpUnitTests.Parsers.Aprs
                     10,
                     50));
 
-            Assert.Equal(encodedPacket, p.Encode());
-            Assert.Equal(encodedPacket, packetToEncode.Encode());
+            Assert.Equal(encodedPacket, p.EncodeTnc2());
+            Assert.Equal(encodedPacket, packetToEncode.EncodeTnc2());
         }
 
         /// <summary>


### PR DESCRIPTION
## Description

Renames `string Packet.Encode()` to explicit `string Packet.EncodeTnc2()` to make way for upcoming AX.25 byte encoding work. AX.25 requires encode to bytes, but TNC2 can encode to string without losing data. Separating the implementations now allows their logic to evolve separately as we go forward.

This is the first PR for #145

## Changes

* Rename `Packet.Encode` to `Packet.EncodeTnc2`
* Update references in tests

## Validation

* Linting and tests pass
