### PR TITLE
Correct WeatherInfo display indentation

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -60,19 +60,19 @@
 
                 if (p.InfoField is WeatherInfo wi)
                 {
-                    Console.WriteLine($"Wind direction (degrees): {wi.WindDirection}");
-                    Console.WriteLine($"Wind speed (one-minute sustained): {wi.WindSpeed}");
-                    Console.WriteLine($"Wind gust (5 minute max, mph): {wi.WindGust}");
-                    Console.WriteLine($"Temperature (F): {wi.Temperature}");
-                    Console.WriteLine($"1-hour rainfall (100th of inch): {wi.Rainfall1Hour}");
-                    Console.WriteLine($"24-hour rainfall (100th of inch): {wi.Rainfall24Hour}");
-                    Console.WriteLine($"Rainfall since midnight (100th of inch): {wi.RainfallSinceMidnight}");
-                    Console.WriteLine($"Humidity: {wi.Humidity}");
-                    Console.WriteLine($"Barometric pressure: {wi.BarometricPressure}");
-                    Console.WriteLine($"Luminosity: {wi.Luminosity}");
-                    Console.WriteLine($"Raw rain: {wi.RainRaw}");
-                    Console.WriteLine($"Snow (inches, last 24 hours): {wi.Snow}");
-                    Console.WriteLine($"Weather Comment: {wi.Comment}");
+                    Console.WriteLine($"    Wind direction (degrees): {wi.WindDirection}");
+                    Console.WriteLine($"    Wind speed (one-minute sustained): {wi.WindSpeed}");
+                    Console.WriteLine($"    Wind gust (5 minute max, mph): {wi.WindGust}");
+                    Console.WriteLine($"    Temperature (F): {wi.Temperature}");
+                    Console.WriteLine($"    1-hour rainfall (100th of inch): {wi.Rainfall1Hour}");
+                    Console.WriteLine($"    24-hour rainfall (100th of inch): {wi.Rainfall24Hour}");
+                    Console.WriteLine($"    Rainfall since midnight (100th of inch): {wi.RainfallSinceMidnight}");
+                    Console.WriteLine($"    Humidity: {wi.Humidity}");
+                    Console.WriteLine($"    Barometric pressure: {wi.BarometricPressure}");
+                    Console.WriteLine($"    Luminosity: {wi.Luminosity}");
+                    Console.WriteLine($"    Raw rain: {wi.RainRaw}");
+                    Console.WriteLine($"    Snow (inches, last 24 hours): {wi.Snow}");
+                    Console.WriteLine($"    Weather Comment: {wi.Comment}");
                 }
             }
             else if (p.InfoField is StatusInfo si)


### PR DESCRIPTION
## Description

`WeatherInfo` packets are being displayed with inconsistent indentation. Basic information is correctly indented to 4 spaces, but the remaining weather info is not indented at all. This change fixes that.

## Changes

* Adds indentation to `WeatherInfo` display code in APRSsharp CLI

## Validation

* Manual testing shows correct indentation
