### PR TITLE
Remove package references to unused nuget packages

### DIFF
--- a/src/APRSsharp/APRSsharp.csproj
+++ b/src/APRSsharp/APRSsharp.csproj
@@ -17,8 +17,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.20574.7" />
-    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.20574.7" />
   </ItemGroup>
 
 

--- a/src/APRSsharp/APRSsharp.csproj
+++ b/src/APRSsharp/APRSsharp.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.5" />
   </ItemGroup>
 
 


### PR DESCRIPTION
## Description

There are a few nuget packages that are not referenced or used in the code, though some of the dependencies of the dependencies are used. This removes the unused packages and adds an explicit dependency on what is required.

## Changes

* Remove package reference to unused nuget packages
* Adds an explicit reference to the correct dependency

## Validation

* Tests pass
* Linting passes
* Manually running APRSsharp CLI works
