### PR TITLE
Add new `UnsupportedInfo` info field type to display unsupported packet types

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -148,14 +148,16 @@
                     getDefaultValue: () => LogLevel.Warning,
                     description: "Set the verbosity of console logging."),
                 new Option<bool>(
-                    aliases: new string[] { "--decode-unsupported" },
+                    aliases: new string[] { "--display-unsupported" },
                     getDefaultValue: () => false,
                     description: "If specified, includes output of unknown or unsupported info types values. If not, such packets are not displayed."),
                 };
             rootCommand.Description = "AprsSharp Console App";
 
             // The parameters of the handler method are matched according to the names of the options
-            rootCommand.Handler = CommandHandler.Create<Mode, string, string, string, int, string, LogLevel, bool>(Execute);
+            rootCommand.Handler = CommandHandler
+                .Create(async (Mode mode, string callsign, string password, string server, int port, string filter, LogLevel verbosity, bool displayUnsuported)
+                        => await Execute(mode, callsign, password, server, port, filter, verbosity, displayUnsuported));
 
             rootCommand.Invoke(args);
         }

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -18,6 +18,11 @@
     public class Program
     {
         /// <summary>
+        /// If true, display unsupported <see cref="InfoField"/> types as raw encoding.
+        /// </summary>
+        private static bool displayUnsupported = false;
+
+        /// <summary>
         /// The modes in which this program can operate.
         /// </summary>
         public enum Mode
@@ -39,6 +44,11 @@
         /// <param name="p">A <see cref="Packet"/> to be printed.</param>
         public static void PrintPacket(Packet p)
         {
+            if (!Program.displayUnsupported && p.InfoField is UnsupportedInfo)
+            {
+                return;
+            }
+
             Console.WriteLine();
             Console.WriteLine($"Received type: {p.InfoField.Type}");
 
@@ -92,6 +102,10 @@
                 Console.WriteLine($"    Message: {mi.Content}");
                 Console.WriteLine($"    ID: {mi.Id}");
             }
+            else if (p.InfoField is UnsupportedInfo ui)
+            {
+                Console.WriteLine($"    Content: {ui.Content}");
+            }
 
             Console.WriteLine();
         }
@@ -133,11 +147,15 @@
                     aliases: new string[] { "--verbosity", "-v" },
                     getDefaultValue: () => LogLevel.Warning,
                     description: "Set the verbosity of console logging."),
+                new Option<bool>(
+                    aliases: new string[] { "--decode-unsupported" },
+                    getDefaultValue: () => false,
+                    description: "If specified, includes output of unknown or unsupported info types values. If not, such packets are not displayed."),
                 };
             rootCommand.Description = "AprsSharp Console App";
 
             // The parameters of the handler method are matched according to the names of the options
-            rootCommand.Handler = CommandHandler.Create<Mode, string, string, string, int, string, LogLevel>(Execute);
+            rootCommand.Handler = CommandHandler.Create<Mode, string, string, string, int, string, LogLevel, bool>(Execute);
 
             rootCommand.Invoke(args);
         }
@@ -152,6 +170,7 @@
         /// <param name="port">A port to use for connection in TCP TNC.</param>
         /// <param name="filter">The filter that will be used for receiving the packets.</param>
         /// <param name="verbosity">The minimum level for an event to be logged to the console.</param>
+        /// <param name="displayUnsupported">If true, display packets with unsupported info field types. If false, such packets are not displayed.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         public static async Task Execute(
             Mode mode,
@@ -160,7 +179,8 @@
             string server,
             int port,
             string filter,
-            LogLevel verbosity)
+            LogLevel verbosity,
+            bool displayUnsupported)
         {
             using ILoggerFactory loggerFactory = LoggerFactory.Create(config =>
             {
@@ -168,6 +188,8 @@
                     .AddConsole()
                     .SetMinimumLevel(verbosity);
             });
+
+            Program.displayUnsupported = displayUnsupported;
 
             switch (mode)
             {

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -147,17 +147,16 @@
                     aliases: new string[] { "--verbosity", "-v" },
                     getDefaultValue: () => LogLevel.Warning,
                     description: "Set the verbosity of console logging."),
-                new Option<bool>(
+                new Option(
                     aliases: new string[] { "--display-unsupported" },
-                    getDefaultValue: () => false,
                     description: "If specified, includes output of unknown or unsupported info types values. If not, such packets are not displayed."),
                 };
             rootCommand.Description = "AprsSharp Console App";
 
             // The parameters of the handler method are matched according to the names of the options
             rootCommand.Handler = CommandHandler
-                .Create(async (Mode mode, string callsign, string password, string server, int port, string filter, LogLevel verbosity, bool displayUnsuported)
-                        => await Execute(mode, callsign, password, server, port, filter, verbosity, displayUnsuported));
+                .Create(async (Mode mode, string callsign, string password, string server, int port, string filter, LogLevel verbosity, bool displayUnsupported)
+                        => await Execute(mode, callsign, password, server, port, filter, verbosity, displayUnsupported));
 
             rootCommand.Invoke(args);
         }

--- a/src/AprsParser/InfoField/InfoField.cs
+++ b/src/AprsParser/InfoField/InfoField.cs
@@ -87,7 +87,7 @@
                     return new MessageInfo(encodedInfoField);
 
                 default:
-                    throw new NotImplementedException($"FromString not implemented for info field type {type}");
+                    return new UnsupportedInfo(encodedInfoField);
             }
         }
 

--- a/src/AprsParser/InfoField/UnsupportedInfo.cs
+++ b/src/AprsParser/InfoField/UnsupportedInfo.cs
@@ -31,5 +31,5 @@ public class UnsupportedInfo : InfoField
     /// </summary>
     /// <throws><see cref="NotImplementedException"/>.</throws>
     /// <returns>Nothing, not implemented.</returns>
-    public override string Encode() => throw new NotImplementedException($"{nameof(UnsupportedInfo)} should not be used to encode packets for transmission. Please use a supported type.");
+    public override string Encode() => throw new NotSupportedException($"{nameof(UnsupportedInfo)} should not be used to encode packets for transmission. Please use a supported type.");
 }

--- a/src/AprsParser/InfoField/UnsupportedInfo.cs
+++ b/src/AprsParser/InfoField/UnsupportedInfo.cs
@@ -1,5 +1,7 @@
 namespace AprsSharp.Parsers.Aprs;
 
+using System;
+
 /// <summary>
 /// Represents an info field that is not supported by APRS#.
 /// </summary>
@@ -20,6 +22,14 @@ public class UnsupportedInfo : InfoField
     /// </summary>
     public string Content { get; }
 
-    /// <inheritdoc/>
-    public override string Encode() => Content;
+    /// <summary>
+    /// Not implemented. <see cref="UnsupportedInfo"/> is to help fill the gap on receive
+    /// and should not be used for transmissions. We do not want to send non-standard packets
+    /// and crowd the APRS airwaves. If you'd like to transmit a packet type that is not yet
+    /// supported in APRS#, consider opening/commenting on an issue or sending a PR to
+    /// implement the type.
+    /// </summary>
+    /// <throws><see cref="NotImplementedException"/>.</throws>
+    /// <returns>Nothing, not implemented.</returns>
+    public override string Encode() => throw new NotImplementedException($"{nameof(UnsupportedInfo)} should not be used to encode packets for transmission. Please use a supported type.");
 }

--- a/src/AprsParser/InfoField/UnsupportedInfo.cs
+++ b/src/AprsParser/InfoField/UnsupportedInfo.cs
@@ -1,0 +1,25 @@
+namespace AprsSharp.Parsers.Aprs;
+
+/// <summary>
+/// Represents an info field that is not supported by APRS#.
+/// </summary>
+public class UnsupportedInfo : InfoField
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UnsupportedInfo"/> class.
+    /// </summary>
+    /// <param name="encodedInfoField">A string encoding of an <see cref="InfoField"/>.</param>
+    public UnsupportedInfo(string encodedInfoField)
+        : base(encodedInfoField)
+    {
+        Content = encodedInfoField;
+    }
+
+    /// <summary>
+    /// Gets the <see cref="InfoField"/> content.
+    /// </summary>
+    public string Content { get; }
+
+    /// <inheritdoc/>
+    public override string Encode() => Content;
+}

--- a/src/AprsParser/InfoField/UnsupportedInfo.cs
+++ b/src/AprsParser/InfoField/UnsupportedInfo.cs
@@ -23,13 +23,13 @@ public class UnsupportedInfo : InfoField
     public string Content { get; }
 
     /// <summary>
-    /// Not implemented. <see cref="UnsupportedInfo"/> is to help fill the gap on receive
+    /// Not supported. <see cref="UnsupportedInfo"/> is to help fill the gap on receive
     /// and should not be used for transmissions. We do not want to send non-standard packets
     /// and crowd the APRS airwaves. If you'd like to transmit a packet type that is not yet
     /// supported in APRS#, consider opening/commenting on an issue or sending a PR to
     /// implement the type.
     /// </summary>
-    /// <throws><see cref="NotImplementedException"/>.</throws>
-    /// <returns>Nothing, not implemented.</returns>
+    /// <throws><see cref="NotSupportedException"/>.</throws>
+    /// <returns>Nothing, not supported.</returns>
     public override string Encode() => throw new NotSupportedException($"{nameof(UnsupportedInfo)} should not be used to encode packets for transmission. Please use a supported type.");
 }

--- a/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
@@ -3,7 +3,6 @@ namespace AprsSharpUnitTests.Parsers.Aprs;
 using System;
 using System.Linq;
 using AprsSharp.Parsers.Aprs;
-using GeoCoordinatePortable;
 using Xunit;
 
 /// <summary>

--- a/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
@@ -1,0 +1,85 @@
+namespace AprsSharpUnitTests.Parsers.Aprs;
+
+using System;
+using System.Linq;
+using AprsSharp.Parsers.Aprs;
+using GeoCoordinatePortable;
+using Xunit;
+
+/// <summary>
+/// Tests code in the <see cref="UnsupportedInfo"/> class for displaying unsupported/unknown formats.
+/// </summary>
+public class UnsupportedInfoUnitTests
+{
+    /// <summary>
+    /// Verifies a (currently) unsupported packet type results in an <see cref="UnsupportedInfo"/>.
+    /// NOTE: This will have to be changed when that type is actually supported.
+    ///     This is currently a packet of "Item Report Format — with Lat/Long position".
+    /// </summary>
+    [Fact]
+    public void TestUnsupportedType()
+    {
+        // "Item Report Format — with Lat/Long position" example from APRS 1.01 Spec
+        string encoded = "N0CALL>WIDE2-2:)AID #2!4903.50N/07201.75WA";
+        Packet p = new Packet(encoded);
+
+        Assert.Equal("N0CALL", p.Sender);
+        Assert.Equal("WIDE2-2", p.Path.Single());
+        Assert.True((p.ReceivedTime - DateTime.UtcNow) < TimeSpan.FromMinutes(1));
+        Assert.Equal(PacketType.Item, p.InfoField.Type);
+        Assert.IsType<UnsupportedInfo>(p.InfoField);
+
+        var ui = p.InfoField as UnsupportedInfo;
+        Assert.Equal(")AID #2!4903.50N/07201.75WA", ui!.Content);
+    }
+
+    /// <summary>
+    /// Verifies an invalid packet type results in an <see cref="UnsupportedInfo"/>.
+    /// </summary>
+    [Fact]
+    public void TestInvalidDataType()
+    {
+        // "Invalid Data / Test Data Format" example from APRS 1.01 Spec
+        string encoded = "N0CALL>WIDE2-2:,191146,V,4214.2466,N,07303.5181,W,417.238,114.5,091099,14.7,W/GPS FIX";
+        Packet p = new Packet(encoded);
+
+        Assert.Equal("N0CALL", p.Sender);
+        Assert.Equal("WIDE2-2", p.Path.Single());
+        Assert.True((p.ReceivedTime - DateTime.UtcNow) < TimeSpan.FromMinutes(1));
+        Assert.Equal(PacketType.InvalidOrTestData, p.InfoField.Type);
+        Assert.IsType<UnsupportedInfo>(p.InfoField);
+
+        var ui = p.InfoField as UnsupportedInfo;
+        Assert.Equal(",191146,V,4214.2466,N,07303.5181,W,417.238,114.5,091099,14.7,W/GPS FIX", ui!.Content);
+    }
+
+    /// <summary>
+    /// Verifies that a completely unknown encoding results in an <see cref="UnsupportedInfo"/>.
+    /// </summary>
+    [Fact]
+    public void TestUnknownEncoding()
+    {
+        string encoded = "N0CALL>WIDE2-2:EXAMPLE UNKNOWN ENCODING";
+        Packet p = new Packet(encoded);
+
+        Assert.Equal("N0CALL", p.Sender);
+        Assert.Equal("WIDE2-2", p.Path.Single());
+        Assert.True((p.ReceivedTime - DateTime.UtcNow) < TimeSpan.FromMinutes(1));
+        Assert.Equal(PacketType.Unknown, p.InfoField.Type);
+        Assert.IsType<UnsupportedInfo>(p.InfoField);
+
+        var ui = p.InfoField as UnsupportedInfo;
+        Assert.Equal("EXAMPLE UNKNOWN ENCODING", ui!.Content);
+    }
+
+    /// <summary>
+    /// Verifies that trying to encode an <see cref="UnsupportedInfo"/> results in an exception.
+    /// </summary>
+    [Fact]
+    public void EncodeUnknownThrows()
+    {
+        UnsupportedInfo ui = new UnsupportedInfo("Some data");
+        Packet p = new Packet("N0CALL", Array.Empty<string>(), ui);
+        Assert.Throws<NotSupportedException>(() => p.Encode());
+    }
+}

--- a/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
@@ -79,6 +79,6 @@ public class UnsupportedInfoUnitTests
     {
         UnsupportedInfo ui = new UnsupportedInfo("Some data");
         Packet p = new Packet("N0CALL", Array.Empty<string>(), ui);
-        Assert.Throws<NotSupportedException>(() => p.Encode());
+        Assert.Throws<NotSupportedException>(() => p.EncodeTnc2());
     }
 }


### PR DESCRIPTION
## Description

Introduces `UnsupportedInfo` to allow for displaying partial decode and raw (undecoded) info field from packets with an info field that is not supported by APRS#.
Display of these packets is disabled by default in APRSsharp.exe but can be enabled with the new `--display-unsupported` flag.

`UnsupportedInfo` cannot be used for encoding in an effort to reduce using APRS# to send non-standard packets that might clutter the network.

Resolves #148.

## Changes

* Add `UnsupportedInfo` info field
* Use it for any info field that is not known or supported during packet decode
* Add display of these new types to APRS# CLI app behind optional `--display-unsupported` flag
* Adds new tests

## Validation

* Manually tested against APRSIS to display or not display based on flag in CLI app
* Added new tests
