### PR TITLE
Implement AX.25 TNC Send and Receive

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -54,6 +54,7 @@
             Console.WriteLine($"Received type: {p.InfoField.Type}");
 
             Console.WriteLine($"    Sender: {p.Sender}");
+            Console.WriteLine($"    Destination: {p.Destination}");
             Console.WriteLine($"    Path: {string.Join(',', p.Path)}");
             Console.WriteLine($"    Received At: {p.ReceivedTime} {p.ReceivedTime?.Kind}");
             Console.WriteLine($"    Type: {p.InfoField.Type}");
@@ -229,7 +230,10 @@
                     tnc.FrameReceivedEvent += (sender, args) =>
                     {
                         var byteArray = args.Data.ToArray();
-                        Console.WriteLine(Encoding.UTF8.GetString(byteArray));
+                        var encodedPacket = Encoding.UTF8.GetString(byteArray);
+                        Console.WriteLine(encodedPacket);
+                        var packet = new Packet(encodedPacket);
+                        PrintPacket(packet);
                     };
 
                     Console.WriteLine("Press Q to quit");

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -230,9 +230,7 @@
                     tnc.FrameReceivedEvent += (sender, args) =>
                     {
                         var byteArray = args.Data.ToArray();
-                        var encodedPacket = Encoding.UTF8.GetString(byteArray);
-                        Console.WriteLine(encodedPacket);
-                        var packet = new Packet(encodedPacket);
+                        var packet = new Packet(byteArray);
                         PrintPacket(packet);
                     };
 

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -1,6 +1,7 @@
 ﻿namespace AprsSharp.Applications.Console
 {
     using System;
+    using System.Collections.Generic;
     using System.CommandLine;
     using System.CommandLine.Invocation;
     using System.Linq;
@@ -234,14 +235,20 @@
                         PrintPacket(packet);
                     };
 
-                    Console.WriteLine("Press Q to quit");
-                    ConsoleKey key;
+                    Console.WriteLine("Enter status to send, else q to quit");
 
                     do
                     {
-                        key = Console.ReadKey().Key;
+                        var input = Console.ReadLine();
+                        if (string.Equals(input, "q", StringComparison.OrdinalIgnoreCase))
+                        {
+                            break;
+                        }
+
+                        var packet = new Packet(callsign, new List<string>(), new StatusInfo((Timestamp?)null, input));
+                        tnc.SendData(packet.EncodeAx25());
                     }
-                    while (key != ConsoleKey.Q);
+                    while (true);
 
                     break;
                 }

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -235,6 +235,9 @@
                         PrintPacket(packet);
                     };
 
+                    tnc.SetTxDelay(50);
+                    tnc.SetTxTail(50);
+
                     Console.WriteLine("Enter status to send, else q to quit");
 
                     do
@@ -245,7 +248,7 @@
                             break;
                         }
 
-                        var packet = new Packet(callsign, new List<string>(), new StatusInfo((Timestamp?)null, input));
+                        var packet = new Packet(callsign, callsign, new List<string>(), new StatusInfo((Timestamp?)null, input));
                         tnc.SendData(packet.EncodeAx25());
                     }
                     while (true);

--- a/src/APRSsharp/Properties/launchSettings.json
+++ b/src/APRSsharp/Properties/launchSettings.json
@@ -2,7 +2,8 @@
   "profiles": {
     "APRSsharp": {
       "commandName": "Project",
-      "commandLineArgs": "--mode TCPTNC --server localhost --port 8001"
+      "commandLineArgs": "--mode TCPTNC --server localhost --port 8001 --callsign KG5GHQ",
+      "nativeDebugging": true
     }
   }
 }

--- a/src/APRSsharp/Properties/launchSettings.json
+++ b/src/APRSsharp/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "APRSsharp": {
       "commandName": "Project",
-      "commandLineArgs": "--mode TCPTNC --server localhost --port 8001 --callsign KG5GHQ",
+      "commandLineArgs": "--mode TCPTNC --server localhost --port 8001",
       "nativeDebugging": true
     }
   }

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -45,6 +45,22 @@
         }
 
         /// <summary>
+        /// Specifies different formats for a <see cref="Packet"/>.
+        /// </summary>
+        public enum Format
+        {
+            /// <summary>
+            /// The TNC2 format.
+            /// </summary>
+            TNC2,
+
+            /// <summary>
+            /// The AX.25 packet format.
+            /// </summary>
+            AX25,
+        }
+
+        /// <summary>
         /// Gets the sender's callsign.
         /// </summary>
         public string Sender { get; }
@@ -72,6 +88,15 @@
         public string EncodeTnc2()
         {
             return $"{Sender}>{string.Join(',', Path)}:{InfoField.Encode()}";
+        }
+
+        /// <summary>
+        /// Encodes an APRS packet as bytes in AX.25 format.
+        /// </summary>
+        /// <returns>Byte encoding of packet in AX.25 format.</returns>
+        public byte[] EncodeAx25()
+        {
+            throw new NotImplementedException($"Encoding not implemented for {nameof(Format.AX25)}");
         }
     }
 }

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -68,8 +68,21 @@
         /// <param name="path">The digipath for the packet.</param>
         /// <param name="infoField">An <see cref="InfoField"/> or extending class to send.</param>
         public Packet(string sender, IList<string> path, InfoField infoField)
+            : this(sender, null, path, infoField)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Packet"/> class.
+        /// </summary>
+        /// <param name="sender">The callsign of the sender.</param>
+        /// <param name="destination">The callsign of the destination.</param>
+        /// <param name="path">The digipath for the packet.</param>
+        /// <param name="infoField">An <see cref="InfoField"/> or extending class to send.</param>
+        public Packet(string sender, string? destination, IList<string> path, InfoField infoField)
         {
             Sender = sender;
+            Destination = destination;
             Path = path;
             InfoField = infoField;
             ReceivedTime = null;
@@ -163,8 +176,13 @@
             var numBytes = 16 + (Path.Count * 7) + encodedInfoField.Length;
             var encodedBytes = new byte[numBytes];
 
-            EncodeCallsignBytes(Destination).CopyTo(encodedBytes, 0);
-            EncodeCallsignBytes(Sender, Path.Count == 0).CopyTo(encodedBytes, 8);
+            var offset = 0;
+
+            EncodeCallsignBytes(Destination).CopyTo(encodedBytes, offset);
+            offset += 7;
+
+            EncodeCallsignBytes(Sender, Path.Count == 0).CopyTo(encodedBytes, offset);
+            offset += 7;
 
             if (Path.Count > 8)
             {
@@ -173,13 +191,18 @@
 
             for (var i = 0; i < Path.Count; ++i)
             {
-                EncodeCallsignBytes(Path[i], i == (Path.Count - 1)).CopyTo(encodedBytes, 15 + (7 * i));
+                EncodeCallsignBytes(Path[i], i == (Path.Count - 1)).CopyTo(encodedBytes, offset);
+                offset += 7;
             }
 
-            encodedBytes[15 + (7 * Path.Count)] = (byte)Ax25Control.UI_FRAME;
-            encodedBytes[15 + (7 * Path.Count) + 1] = (byte)Ax25Control.NO_LAYER_THREE_PROTOCOL;
+            encodedBytes[offset] = (byte)Ax25Control.UI_FRAME;
+            offset += 1;
 
-            Encoding.ASCII.GetBytes(encodedInfoField).CopyTo(encodedBytes, 14 + (7 * Path.Count) + 2);
+            encodedBytes[offset] = (byte)Ax25Control.NO_LAYER_THREE_PROTOCOL;
+            offset += 1;
+
+            Encoding.ASCII.GetBytes(encodedInfoField).CopyTo(encodedBytes, offset);
+
             return encodedBytes;
         }
 

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -89,23 +89,7 @@
         }
 
         /// <summary>
-        /// Specifies different formats for a <see cref="Packet"/>.
-        /// </summary>
-        public enum Format
-        {
-            /// <summary>
-            /// The TNC2 format.
-            /// </summary>
-            TNC2,
-
-            /// <summary>
-            /// The AX.25 packet format.
-            /// </summary>
-            AX25,
-        }
-
-        /// <summary>
-        /// Special values used in <see cref="Format.AX25"/> encoding.
+        /// Special values used in AX.25 encoding.
         /// </summary>
         private enum Ax25Control : byte
         {
@@ -207,7 +191,7 @@
         }
 
         /// <summary>
-        /// Attempts to get a callsign from an encoded <see cref="Format.AX25"/> packet.
+        /// Attempts to get a callsign from an encoded AX.25 packet.
         /// </summary>
         /// <param name="encodedPacket">The bytes of the encoded packet.</param>
         /// <param name="callsignNumber">The number of the callsign (in order in the packet encoding) to attempt to fetch.</param>

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -158,6 +158,12 @@
             throw new NotImplementedException($"Encoding not implemented for {nameof(Format.AX25)}");
         }
 
+        /// <summary>
+        /// Attempts to get a callsign from an encoded <see cref="Format.AX25"/> packet.
+        /// </summary>
+        /// <param name="encodedPacket">The bytes of the encoded packet.</param>
+        /// <param name="callsignNumber">The number of the callsign (in order in the packet encoding) to attempt to fetch.</param>
+        /// <returns>A callsign string if successful, else null.</returns>
         private static string? GetCallsignFromAx25(IEnumerable<byte> encodedPacket, int callsignNumber)
         {
             int callsignStart = 1 + (callsignNumber * 7);
@@ -169,7 +175,10 @@
                     return null;
                 }
 
-            return $"{Encoding.UTF8.GetString(encodedPacket.Skip(callsignStart).Take(6).ToArray())}-{encodedPacket.ElementAt(callsignStart + 6)}";
+            var callsign = Encoding.UTF8.GetString(encodedPacket.Skip(callsignStart).Take(6).ToArray());
+            var ssid = encodedPacket.ElementAt(callsignStart + 6);
+
+            return ssid == 0x0 ? callsign : $"{callsign}-{ssid}";
         }
     }
 }

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -196,7 +196,7 @@
 
             var raw = encodedPacket.Skip(callsignStart).Take(6);
             var shifted = raw.Select(r => (byte)(r >> 1)).ToArray();
-            var callsign = Encoding.UTF8.GetString(shifted).Trim();
+            var callsign = Encoding.ASCII.GetString(shifted).Trim();
 
             var ssid = encodedPacket.ElementAt(callsignStart + 6);
 
@@ -222,7 +222,7 @@
         {
             if (callsign == null)
             {
-                return Encoding.UTF8.GetBytes(new string(' ', 6)).Append((byte)0).ToArray();
+                return Encoding.ASCII.GetBytes(new string(' ', 6)).Append((byte)0).ToArray();
             }
 
             var matches = Regex.Match(callsign, RegexStrings.CallsignWithOptionalSsid);
@@ -246,7 +246,7 @@
                 ssidByte |= 0x1;
             }
 
-            var shiftedBytes = Encoding.UTF8.GetBytes(call).Select(raw => (byte)(raw << 1)).ToArray();
+            var shiftedBytes = Encoding.ASCII.GetBytes(call).Select(raw => (byte)(raw << 1)).ToArray();
             return shiftedBytes.Append(ssidByte).ToArray();
         }
     }

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -16,10 +16,10 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="Packet"/> class.
         /// </summary>
-        /// <param name="encodedPacket">The string encoding of the APRS packet.</param>
-        public Packet(string encodedPacket)
+        /// <param name="encodedPacket">The encoded APRS packet.</param>
+        public Packet(byte[] encodedPacket)
         {
-            if (string.IsNullOrWhiteSpace(encodedPacket))
+            if (encodedPacket == null || encodedPacket.Length == 0)
             {
                 throw new ArgumentNullException(nameof(encodedPacket));
             }
@@ -27,7 +27,7 @@
             ReceivedTime = DateTime.UtcNow;
 
             // Attempt to decode TNC2 format
-            Match match = Regex.Match(encodedPacket, RegexStrings.Tnc2Packet);
+            Match match = Regex.Match(Encoding.ASCII.GetString(encodedPacket), RegexStrings.Tnc2Packet);
             if (match.Success)
             {
                 match.AssertSuccess("Full TNC2 Packet", nameof(encodedPacket));
@@ -38,19 +38,27 @@
             }
 
             // Next attempt to decode AX.25 format
-            var packetBytes = Encoding.UTF8.GetBytes(encodedPacket);
-            Destination = GetCallsignFromAx25(packetBytes, 0, out _);
-            Sender = GetCallsignFromAx25(packetBytes, 1, out bool isFinalAddress);
+            Destination = GetCallsignFromAx25(encodedPacket, 0, out _);
+            Sender = GetCallsignFromAx25(encodedPacket, 1, out bool isFinalAddress);
             Path = new List<string>();
 
             for (var i = 2; !isFinalAddress && i < 10; ++i)
             {
-                var pathEntry = GetCallsignFromAx25(packetBytes, i, out isFinalAddress);
+                var pathEntry = GetCallsignFromAx25(encodedPacket, i, out isFinalAddress);
                 Path.Add(pathEntry);
             }
 
-            var infoBytes = packetBytes.Skip(((Path.Count + 2) * 7) + 2);
-            InfoField = InfoField.FromString(Encoding.UTF8.GetString(infoBytes.ToArray()));
+            var infoBytes = encodedPacket.Skip(((Path.Count + 2) * 7) + 2);
+            InfoField = InfoField.FromString(Encoding.ASCII.GetString(infoBytes.ToArray()));
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Packet"/> class.
+        /// </summary>
+        /// <param name="encodedPacket">A string representation of an encoded packet.</param>
+        public Packet(string encodedPacket)
+            : this(Encoding.ASCII.GetBytes(encodedPacket))
+        {
         }
 
         /// <summary>

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -163,8 +163,8 @@
             var numBytes = 16 + (Path.Count * 7) + encodedInfoField.Length;
             var encodedBytes = new byte[numBytes];
 
-            EncodeCallsignBytes(Destination).CopyTo(encodedBytes, 8);
-            EncodeCallsignBytes(Sender, Path.Count == 0).CopyTo(encodedBytes, 1);
+            EncodeCallsignBytes(Destination).CopyTo(encodedBytes, 0);
+            EncodeCallsignBytes(Sender, Path.Count == 0).CopyTo(encodedBytes, 8);
 
             if (Path.Count > 8)
             {
@@ -179,8 +179,7 @@
             encodedBytes[15 + (7 * Path.Count)] = (byte)Ax25Control.UI_FRAME;
             encodedBytes[15 + (7 * Path.Count) + 1] = (byte)Ax25Control.NO_LAYER_THREE_PROTOCOL;
 
-            Encoding.UTF8.GetBytes(encodedInfoField).CopyTo(encodedBytes, 15 + (7 * Path.Count) + 2);
-
+            Encoding.ASCII.GetBytes(encodedInfoField).CopyTo(encodedBytes, 14 + (7 * Path.Count) + 2);
             return encodedBytes;
         }
 
@@ -230,7 +229,10 @@
             matches.AssertSuccess(nameof(RegexStrings.CallsignWithOptionalSsid), nameof(callsign));
 
             var call = matches.Groups[1].Value.PadRight(6, ' ');
-            var ssid = int.Parse(matches.Groups[3].Value, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            int ssid = int.TryParse(matches.Groups[3].Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out int inputSsid) ?
+                   inputSsid :
+                   0;
+
             if (ssid > 15 || ssid < 0)
             {
                 throw new ArgumentException("SSID must be in range [0,15]", nameof(callsign));

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -114,5 +114,15 @@ namespace AprsSharp.Parsers.Aprs
         ///     MessageId (excludes `{`).
         /// </summary>
         public const string MessageWithId = @"^:(.{9}):([^:~{]+)?({([a-zA-Z0-9]{1,5}))?$";
+
+        /// <summary>
+        /// Matches a callsign with optional SSID
+        /// 4 matches:
+        ///     Full
+        ///     Callsign (no SSID)
+        ///     SSID suffix (include dash) (optional)
+        ///     SSID number (optional).
+        /// </summary>
+        public const string CallsignWithOptionalSsid = @"^([a-zA-Z0-9]{1,6})(-([0-9]{1,2}))?$";
     }
 }

--- a/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
@@ -3,7 +3,6 @@ namespace AprsSharpUnitTests.Parsers.Aprs
     using System;
     using System.Linq;
     using AprsSharp.Parsers.Aprs;
-    using GeoCoordinatePortable;
     using Xunit;
 
     /// <summary>

--- a/test/AprsParserUnitTests/PacketAx25UnitTests.cs
+++ b/test/AprsParserUnitTests/PacketAx25UnitTests.cs
@@ -1,0 +1,42 @@
+﻿namespace AprsSharpUnitTests.Parsers.Aprs;
+
+using System;
+using AprsSharp.Parsers.Aprs;
+using Xunit;
+
+/// <summary>
+/// Tests <see cref="Packet"/> code for encoding and decoding AX.25 packet format.
+/// </summary>
+public class PacketAx25UnitTests
+{
+    /// <summary>
+    /// Tests a full roundtrip encode then decode in AX.25.
+    /// </summary>
+    [Fact]
+    public void RoundTripEncodeDecode()
+    {
+        var sender = "N0CALL";
+        var destination = "N0NE";
+        var path = new string[2] { "WIDE2-2", "WIDE1-1" };
+        var info = new StatusInfo(new Timestamp(DateTime.UtcNow), "Testing 1 2 3!");
+
+        var packet = new Packet(sender, destination, path, info);
+
+        var encoded = packet.EncodeAx25();
+
+        var decodedPacket = new Packet(encoded);
+
+        Assert.Equal(sender, decodedPacket.Sender);
+        Assert.Equal(destination, decodedPacket.Destination);
+        Assert.Equal(path, decodedPacket.Path);
+
+        Assert.IsType<StatusInfo>(decodedPacket.InfoField);
+        var si = (StatusInfo)decodedPacket.InfoField ?? throw new Exception();
+        Assert.Equal(DateTimeKind.Utc, si.Timestamp?.DateTime.Kind);
+        Assert.Equal(info.Timestamp?.DateTime.Day, si.Timestamp?.DateTime.Day);
+        Assert.Equal(info.Timestamp?.DateTime.Hour, si.Timestamp?.DateTime.Hour);
+        Assert.Equal(info.Timestamp?.DateTime.Minute, si.Timestamp?.DateTime.Minute);
+        Assert.Equal(info.Comment, si.Comment);
+        Assert.Equal(info.Position?.Coordinates, si.Position?.Coordinates);
+    }
+}


### PR DESCRIPTION
## Description

Implements AX.25 TNC send and receive via TCP IP. Done as a lump to allow testing with real hardware and direwolf for a TCP connected TNC.

Resolves #144 
Resolves #145
Resolves #147 

## Changes

* Switches packet decode to be bytes instead of string
* Implements AX.25 encode
* Implements AX.25 decode
* Adds AX.25 encode-decode test
* Adds ability to send packet via TCP TNC in APRSsharp.exe

## Validation

* Tests pass
* Manual validation with hardware and direwolf
