### PR TITLE
Update namespaces to match nuget package names

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -6,7 +6,7 @@
     using System.CommandLine.Invocation;
     using System.Linq;
     using System.Threading.Tasks;
-    using AprsSharp.Connections.AprsIs;
+    using AprsSharp.AprsIsClient;
     using AprsSharp.KissTnc;
     using AprsSharp.Parsers.Aprs;
     using AprsSharp.Shared;

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -8,7 +8,7 @@
     using System.Threading.Tasks;
     using AprsSharp.AprsIsClient;
     using AprsSharp.KissTnc;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using AprsSharp.Shared;
     using Microsoft.Extensions.Logging;
 

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -7,8 +7,8 @@
     using System.Linq;
     using System.Threading.Tasks;
     using AprsSharp.AprsIsClient;
-    using AprsSharp.KissTnc;
     using AprsSharp.AprsParser;
+    using AprsSharp.KissTnc;
     using AprsSharp.Shared;
     using Microsoft.Extensions.Logging;
 

--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -4,7 +4,7 @@
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using AprsSharp.Shared;
     using Microsoft.Extensions.Logging;
 

--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -1,4 +1,4 @@
-﻿namespace AprsSharp.Connections.AprsIs
+﻿namespace AprsSharp.AprsIsClient
 {
     using System;
     using System.Reflection;

--- a/src/AprsIsClient/ConnectionState.cs
+++ b/src/AprsIsClient/ConnectionState.cs
@@ -1,4 +1,4 @@
-﻿namespace AprsSharp.Connections.AprsIs
+﻿namespace AprsSharp.AprsIsClient
 {
     /// <summary>
     /// Tracks the state of an <see cref="AprsIsClient"/>.

--- a/src/AprsParser/Enums/CoordinateSystem.cs
+++ b/src/AprsParser/Enums/CoordinateSystem.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     /// <summary>
     /// Specifies whether a function is referring to latitude or longitude during Maidenhead gridsquare encode/decode.

--- a/src/AprsParser/Enums/NmeaType.cs
+++ b/src/AprsParser/Enums/NmeaType.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     /// <summary>
     /// Used to specify format during decode of raw GPS data packets.

--- a/src/AprsParser/Enums/PacketType.cs
+++ b/src/AprsParser/Enums/PacketType.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     /// <summary>
     /// The APRS packet type.

--- a/src/AprsParser/Enums/TimestampType.cs
+++ b/src/AprsParser/Enums/TimestampType.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     /// <summary>
     /// Represents the type of APRS timestamp.

--- a/src/AprsParser/Extensions/EnumConversionExtensions.cs
+++ b/src/AprsParser/Extensions/EnumConversionExtensions.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs.Extensions
+namespace AprsSharp.AprsParser.Extensions
 {
     using System;
     using System.Collections.Generic;

--- a/src/AprsParser/Extensions/MatchExtensions.cs
+++ b/src/AprsParser/Extensions/MatchExtensions.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs.Extensions
+namespace AprsSharp.AprsParser.Extensions
 {
     using System;
     using System.Text.RegularExpressions;

--- a/src/AprsParser/Extensions/WeatherExtensions.cs
+++ b/src/AprsParser/Extensions/WeatherExtensions.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs.Extensions
+namespace AprsSharp.AprsParser.Extensions
 {
     using System;
     using System.Globalization;

--- a/src/AprsParser/InfoField/InfoField.cs
+++ b/src/AprsParser/InfoField/InfoField.cs
@@ -1,7 +1,7 @@
-﻿namespace AprsSharp.Parsers.Aprs
+﻿namespace AprsSharp.AprsParser
 {
     using System;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
 
     /// <summary>
     /// A representation of an info field on an APRS packet.

--- a/src/AprsParser/InfoField/MaidenheadBeaconInfo.cs
+++ b/src/AprsParser/InfoField/MaidenheadBeaconInfo.cs
@@ -1,9 +1,9 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     using System;
     using System.Text;
     using System.Text.RegularExpressions;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
 
     /// <summary>
     /// Represents an info field for packet type <see cref="PacketType.MaidenheadGridLocatorBeacon"/>.

--- a/src/AprsParser/InfoField/MessageInfo.cs
+++ b/src/AprsParser/InfoField/MessageInfo.cs
@@ -1,9 +1,9 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     using System;
     using System.Text;
     using System.Text.RegularExpressions;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
 
     /// <summary>
     /// Represents an info field for packet type <see cref="PacketType.Message"/>.

--- a/src/AprsParser/InfoField/PositionInfo.cs
+++ b/src/AprsParser/InfoField/PositionInfo.cs
@@ -1,9 +1,9 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     using System;
     using System.Text;
     using System.Text.RegularExpressions;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
 
     /// <summary>
     /// Represents an info field for the following types of packet:

--- a/src/AprsParser/InfoField/StatusInfo.cs
+++ b/src/AprsParser/InfoField/StatusInfo.cs
@@ -1,9 +1,9 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     using System;
     using System.Text;
     using System.Text.RegularExpressions;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
 
     /// <summary>
     /// Represents an info field for packet type <see cref="PacketType.Status"/>.

--- a/src/AprsParser/InfoField/UnsupportedInfo.cs
+++ b/src/AprsParser/InfoField/UnsupportedInfo.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs;
+namespace AprsSharp.AprsParser;
 
 using System;
 

--- a/src/AprsParser/InfoField/WeatherInfo.cs
+++ b/src/AprsParser/InfoField/WeatherInfo.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     using System;
     using System.Collections.Generic;
@@ -6,7 +6,7 @@ namespace AprsSharp.Parsers.Aprs
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
 
     /// <summary>
     /// Represents an info field for position packets carrying weather information.

--- a/src/AprsParser/Packet.cs
+++ b/src/AprsParser/Packet.cs
@@ -1,4 +1,4 @@
-﻿namespace AprsSharp.Parsers.Aprs
+﻿namespace AprsSharp.AprsParser
 {
     using System;
     using System.Collections.Generic;
@@ -6,7 +6,7 @@
     using System.Linq;
     using System.Text;
     using System.Text.RegularExpressions;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
 
     /// <summary>
     /// Represents a full APRS packet.

--- a/src/AprsParser/Position.cs
+++ b/src/AprsParser/Position.cs
@@ -1,10 +1,10 @@
-﻿namespace AprsSharp.Parsers.Aprs
+﻿namespace AprsSharp.AprsParser
 {
     using System;
     using System.Globalization;
     using System.Text;
     using System.Text.RegularExpressions;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser.Extensions;
     using GeoCoordinatePortable;
 
     /// <summary>

--- a/src/AprsParser/RegexStrings.cs
+++ b/src/AprsParser/RegexStrings.cs
@@ -1,4 +1,4 @@
-namespace AprsSharp.Parsers.Aprs
+namespace AprsSharp.AprsParser
 {
     /// <summary>
     /// Holds strings for regex comparisons for reuse.

--- a/src/AprsParser/Timestamp.cs
+++ b/src/AprsParser/Timestamp.cs
@@ -1,4 +1,4 @@
-﻿namespace AprsSharp.Parsers.Aprs
+﻿namespace AprsSharp.AprsParser
 {
     using System;
     using System.Globalization;

--- a/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
+++ b/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
@@ -1,7 +1,7 @@
-namespace AprsSharpUnitTests.Connections.AprsIs
+namespace AprsSharpUnitTests.AprsIsClient
 {
     using System.Threading.Tasks;
-    using AprsSharp.Connections.AprsIs;
+    using AprsSharp.AprsIsClient;
     using AprsSharp.Shared;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;

--- a/test/AprsIsClientUnitTests/DisposeUnitTests.cs
+++ b/test/AprsIsClientUnitTests/DisposeUnitTests.cs
@@ -1,6 +1,6 @@
-namespace AprsSharpUnitTests.Connections.AprsIs
+namespace AprsSharpUnitTests.AprsIsClient
 {
-    using AprsSharp.Connections.AprsIs;
+    using AprsSharp.AprsIsClient;
     using AprsSharp.Shared;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -1,9 +1,9 @@
-namespace AprsSharpUnitTests.Connections.AprsIs
+namespace AprsSharpUnitTests.AprsIsClient
 {
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
-    using AprsSharp.Connections.AprsIs;
+    using AprsSharp.AprsIsClient;
     using AprsSharp.Parsers.Aprs;
     using AprsSharp.Shared;
     using Microsoft.Extensions.Logging.Abstractions;

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -4,7 +4,7 @@ namespace AprsSharpUnitTests.AprsIsClient
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using AprsSharp.AprsIsClient;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using AprsSharp.Shared;
     using Microsoft.Extensions.Logging.Abstractions;
     using Moq;

--- a/test/AprsIsClientUnitTests/TimedTestCollection.cs
+++ b/test/AprsIsClientUnitTests/TimedTestCollection.cs
@@ -1,4 +1,4 @@
-namespace AprsSharpUnitTests.Connections.AprsIs
+namespace AprsSharpUnitTests.AprsIsClient
 {
     using Xunit;
 

--- a/test/AprsParserUnitTests/Extensions/EnumConversionExtensionsUnitTests.cs
+++ b/test/AprsParserUnitTests/Extensions/EnumConversionExtensionsUnitTests.cs
@@ -1,7 +1,7 @@
-namespace AprsSharpUnitTests.Parsers.Aprs
+namespace AprsSharpUnitTests.AprsParser
 {
-    using AprsSharp.Parsers.Aprs;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser;
+    using AprsSharp.AprsParser.Extensions;
     using Xunit;
 
     /// <summary>

--- a/test/AprsParserUnitTests/InfoField/InfoFieldUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/InfoFieldUnitTests.cs
@@ -1,6 +1,6 @@
-﻿namespace AprsSharpUnitTests.Parsers.Aprs
+﻿namespace AprsSharpUnitTests.AprsParser
 {
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using Xunit;
 
     /// <summary>

--- a/test/AprsParserUnitTests/InfoField/MaidenheadBeaconInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/MaidenheadBeaconInfoUnitTests.cs
@@ -1,8 +1,8 @@
-﻿namespace AprsSharpUnitTests.Parsers.Aprs
+﻿namespace AprsSharpUnitTests.AprsParser
 {
     using System;
     using System.Linq;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using GeoCoordinatePortable;
     using Xunit;
 

--- a/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/MessageInfoUnitTests.cs
@@ -1,8 +1,8 @@
-namespace AprsSharpUnitTests.Parsers.Aprs
+namespace AprsSharpUnitTests.AprsParser
 {
     using System;
     using System.Linq;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using Xunit;
 
     /// <summary>

--- a/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
@@ -1,7 +1,7 @@
-namespace AprsSharpUnitTests.Parsers.Aprs
+namespace AprsSharpUnitTests.AprsParser
 {
     using System;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using GeoCoordinatePortable;
     using Xunit;
 

--- a/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
@@ -1,8 +1,8 @@
-namespace AprsSharpUnitTests.Parsers.Aprs
+namespace AprsSharpUnitTests.AprsParser
 {
     using System;
     using System.Linq;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using GeoCoordinatePortable;
     using Xunit;
 

--- a/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/UnsupportedInfoUnitTests.cs
@@ -1,8 +1,8 @@
-namespace AprsSharpUnitTests.Parsers.Aprs;
+namespace AprsSharpUnitTests.AprsParser;
 
 using System;
 using System.Linq;
-using AprsSharp.Parsers.Aprs;
+using AprsSharp.AprsParser;
 using Xunit;
 
 /// <summary>

--- a/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
@@ -1,9 +1,9 @@
-namespace AprsSharpUnitTests.Parsers.Aprs
+namespace AprsSharpUnitTests.AprsParser
 {
     using System;
     using System.Collections.Generic;
-    using AprsSharp.Parsers.Aprs;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser;
+    using AprsSharp.AprsParser.Extensions;
     using GeoCoordinatePortable;
     using Xunit;
 

--- a/test/AprsParserUnitTests/NmeaTypeUnitTests.cs
+++ b/test/AprsParserUnitTests/NmeaTypeUnitTests.cs
@@ -1,7 +1,7 @@
-﻿namespace AprsSharpUnitTests.Parsers.Aprs
+﻿namespace AprsSharpUnitTests.AprsParser
 {
-    using AprsSharp.Parsers.Aprs;
-    using AprsSharp.Parsers.Aprs.Extensions;
+    using AprsSharp.AprsParser;
+    using AprsSharp.AprsParser.Extensions;
     using Xunit;
 
     /// <summary>

--- a/test/AprsParserUnitTests/PacketAx25UnitTests.cs
+++ b/test/AprsParserUnitTests/PacketAx25UnitTests.cs
@@ -1,7 +1,7 @@
-﻿namespace AprsSharpUnitTests.Parsers.Aprs;
+﻿namespace AprsSharpUnitTests.AprsParser;
 
 using System;
-using AprsSharp.Parsers.Aprs;
+using AprsSharp.AprsParser;
 using Xunit;
 
 /// <summary>

--- a/test/AprsParserUnitTests/PositionUnitTests.cs
+++ b/test/AprsParserUnitTests/PositionUnitTests.cs
@@ -1,7 +1,7 @@
-﻿namespace AprsSharpUnitTests.Parsers.Aprs
+﻿namespace AprsSharpUnitTests.AprsParser
 {
     using System;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using GeoCoordinatePortable;
     using Xunit;
 

--- a/test/AprsParserUnitTests/TimestampUnitTests.cs
+++ b/test/AprsParserUnitTests/TimestampUnitTests.cs
@@ -1,7 +1,7 @@
-﻿namespace AprsSharpUnitTests.Parsers.Aprs
+﻿namespace AprsSharpUnitTests.AprsParser
 {
     using System;
-    using AprsSharp.Parsers.Aprs;
+    using AprsSharp.AprsParser;
     using Xunit;
 
     /// <summary>


### PR DESCRIPTION
## Description

Updates namespaces to match nuget package names for easier developer experience.

## Changes

* Updates `AprsSharp.Parsers.Aprs` to `AprsSharp.AprsParser`
* Updates `AprsSharp.Connections.AprsIs` to `AprsSharp.AprsIsClient`
* Updates test namespaces

## Validation

* Build and tests pass
