### PR TITLE
Publish Shared package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Pack AprsSharp.KissTnc
         run: dotnet pack src/KissTnc/KissTnc.csproj --configuration Release --no-build
 
+      - name: Pack AprsSharp.Shared
+        run: dotnet pack src/Shared/Shared.csproj --configuration Release --no-build
+
       - name: Publish AprsSharp.AprsParser
         run: dotnet nuget push src/AprsParser/bin/Release/AprsSharp.AprsParser.*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
 
@@ -48,3 +51,6 @@ jobs:
 
       - name: Publish AprsSharp.KissTnc
         run: dotnet nuget push src/KissTnc/bin/Release/AprsSharp.KissTnc.*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json
+
+      - name: Publish AprsSharp.Shared
+        run: dotnet nuget push src/Shared/bin/Release/AprsSharp.Shared.*.nupkg --api-key $NUGET_API_KEY --source https://api.nuget.org/v3/index.json

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <NullableReferenceTypes>true</NullableReferenceTypes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)\analyzers.ruleset</CodeAnalysisRuleSet>
-    <Version>0.3.0</Version>
+    <Version>0.3.1</Version>
     <Authors>Cameron Bielstein</Authors>
     <Company>Cameron Bielstein</Company>
     <PackageProjectUrl>https://github.com/CBielstein/APRSsharp</PackageProjectUrl>

--- a/src/Shared/Shared.csproj
+++ b/src/Shared/Shared.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <PackageId>AprsSharp.Shared</PackageId>
+    <Description>Shared code common to other AprsSharp packages.</Description>
   </PropertyGroup>
 
 </Project>

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -63,7 +63,7 @@ namespace AprsSharpUnitTests.AprsIsClient
             IList<ConnectionState> stateChangesReceived = new List<ConnectionState>();
             TaskCompletionSource loggedIn = new TaskCompletionSource();
 
-            string expectedLoginMessage = $"user N0CALL pass -1 vers AprsSharp 0.3.0 filter r/50.5039/4.4699/50";
+            string expectedLoginMessage = $"user N0CALL pass -1 vers AprsSharp 0.3.1 filter r/50.5039/4.4699/50";
 
             // Mock underlying TCP connection
             string firstMessage = "# server first message";


### PR DESCRIPTION
## Description

The Shared library needs to be published as both `AprsSharp.AprsIsClient` and `AprsSharp.KissTnc` depend on it. Nuget restore step will incorrectly restore a package called `Shared`. This PR publishes `AprsSharp.Shared` so that the shared code can be restored and used.

Version is also bumped to 0.3.1.

## Changes

* Declare `AprsSharp.Shared` as a new package
* Add pack and publish steps
* Bump version to 0.3.1

## Validation

* Build succeeds
* Will release after merge and test restore in a different project
