### PR TITLE
Change build and validation to .NET8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: DotnetVersion
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
           
       - name: restore
         run: dotnet restore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: DotnetVersion
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '6.0.x'
+          dotnet-version: '8.0.x'
 
       - name: Restore
         run: dotnet restore

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To generate the console application binary, go to the APRSsharp folder
 (`AprsSharp\src\APRSsharp`) and run the command `dotnet publish -c Release` to generate
 the console application.
 The resulting binary will be placed in
-`bin\Release\net6.0\win-x86\publish`.
+`bin\Release\net8.0\win-x86\publish`.
 Alternatively, use `dotnet publish -c Release -o <outputfolder>` to specify the
 output directory.
 

--- a/src/APRSsharp/APRSsharp.csproj
+++ b/src/APRSsharp/APRSsharp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>

--- a/src/AprsIsClient/AprsIsClient.csproj
+++ b/src/AprsIsClient/AprsIsClient.csproj
@@ -14,6 +14,7 @@
     <PackageId>AprsSharp.AprsIsClient</PackageId>
     <Description>Library for sending and receiving packets through the Automatic Packet Reporting System Internet Service (APRS-IS)</Description>
     <PackageTags>ham radio;amateur radio;packet radio;radio;APRS;Automatic Packet Reporting System;Automatic Packet Reporting System Internet System;APRS-IS;</PackageTags>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
 </Project>

--- a/test/AprsIsClientUnitTests/AprsIsClientUnitTests.csproj
+++ b/test/AprsIsClientUnitTests/AprsIsClientUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/AprsParserUnitTests/AprsParserUnitTests.csproj
+++ b/test/AprsParserUnitTests/AprsParserUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/KissTncUnitTests/KissTncUnitTests.csproj
+++ b/test/KissTncUnitTests/KissTncUnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/KissTncUnitTests/KissTncUnitTests.csproj
+++ b/test/KissTncUnitTests/KissTncUnitTests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Moq" Version="4.14.6" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Description

Upgrades build and validation to use .NET8.0, which is the latest LTS version. .NET6.0 is out of support now.

## Changes

* Changes target frameworks to .NET8.0
* Changes GitHub Actions to install .NET8.0
* Handles breaking changes:
    * Updates MSTest dependency to fix test discovery failure in .NET8
    * Specifies exclude commit hash in version as per https://learn.microsoft.com/en-us/dotnet/core/compatibility/sdk/8.0/source-link

## Validation

* Build succeeds on local machine with .NET8
* All tests pass on local machine with .NET8
* GitHub Actions will validate in the cloud as part of this PR
