### PR TITLE
Remove eddywine from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, these will
 # be requested for review when someone opens a pull request
-*       @CBielstein @eddywine
+*       @CBielstein


### PR DESCRIPTION
## Description

Removes @eddywine from the codeowners. His early contributions are appreciated, but he isn't actively involved in the project anymore. As always, I will be happy to add him back if/when he would like to return to the project. Thanks for everything, Edwin!

## Changes

* Remove eddywine from codeowners

## Validation

* Will validate that eddywine isn't added to subsequent PRs
