### PR TITLE
Update Runtime Builds for CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ To generate the console application binary, go to the APRSsharp folder
 (`AprsSharp\src\APRSsharp`) and run the command `dotnet publish -c Release` to generate
 the console application.
 The resulting binary will be placed in
-`bin\Release\net8.0\win-x86\publish`.
+`bin/Release/net8.0/<platform>/publish`.
 Alternatively, use `dotnet publish -c Release -o <outputfolder>` to specify the
 output directory.
 

--- a/src/APRSsharp/APRSsharp.csproj
+++ b/src/APRSsharp/APRSsharp.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <PublishReadyToRun>true</PublishReadyToRun>
     <PublishSingleFile>true</PublishSingleFile>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

Updates runtime targets for CLI app. Now targets x64 instead of x86 (as Microsoft winds down support for x86 hardware) and adds Linux x64 now that I've validated on that platform.

## Changes

* Changes runtime build targets to 64-bit of each linux and windows
* Updates readme on publish location

## Validation

* Works on My Machine(TM)
