### PR TITLE
Resolve APRSIS Login Issue

### DIFF
--- a/src/Shared/TcpConnection.cs
+++ b/src/Shared/TcpConnection.cs
@@ -10,6 +10,10 @@
     /// </summary>
     public sealed class TcpConnection : ITcpConnection
     {
+        /// <summary>
+        /// End-of-line bytes that servers expect at the end of a message.
+        /// </summary>
+        private static byte[] eolBytes = Encoding.ASCII.GetBytes("\r\n");
         private readonly TcpClient tcpClient = new TcpClient();
         private NetworkStream? stream;
         private StreamWriter? writer;
@@ -70,6 +74,7 @@
             }
 
             writer.BaseStream.Write(bytes);
+            writer.BaseStream.Write(eolBytes);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
## Description

#153 resulted resulted in a regression with APRS-IS. That was reported by #161 (thanks @ShawnStoddard ) . The issue is described in comments there but, briefly, the change in how TCP messages were being sent meant the newline characters expected by APRS-IS servers were no longer being appended to messages. This PR resolves #161 by adding explicit newline bytes to the sent message.

Manual testing confirms the fix on APRS-IS. However, due to the layers of abstraction, this is a bit difficult to test in an automated fashion. For now, we'll just rely on end-to-end manual testing.

## Changes

* Removes unnecessary newline arg as we aren't using strings and lines in TCP connections anymore
* Manually sends the newline bytes after each message

## Validation

* Manually confirmed that I didn't receive from APRS-IS before the change, but now successfully log in afterward
* Manually confirmed that I can still send messages via TCP connection to Direwolf
