### PR TITLE
Resolve double "filter" in default filtering

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -171,7 +171,8 @@
         /// <param name="password">The user password.</param>
         /// <param name="server">The specified server to connect (either APRS-IS or TCP TNC).</param>
         /// <param name="port">A port to use for connection in TCP TNC.</param>
-        /// <param name="filter">The filter that will be used for receiving the packets.</param>
+        /// <param name="filter">The filter that will be used for receiving the packets.
+        /// This parameter shouldn't include the `filter` at the start, just the logic string itself.</param>
         /// <param name="verbosity">The minimum level for an event to be logged to the console.</param>
         /// <param name="displayUnsupported">If true, display packets with unsupported info field types. If false, such packets are not displayed.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -144,7 +144,7 @@
                 new Option<string>(
                     aliases: new string[] { "--filter", "-f" },
                     getDefaultValue: () => AprsIsClient.AprsIsConstants.DefaultFilter,
-                    description: "A user filter parsed as a string"),
+                    description: "A user filter parsed as a string. Should not include the word 'filter', just the logic string."),
                 new Option<LogLevel>(
                     aliases: new string[] { "--verbosity", "-v" },
                     getDefaultValue: () => LogLevel.Warning,

--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -113,7 +113,8 @@
         /// <param name="password">The users password string.</param>
         /// <param name="server">The APRS-IS server to contact.</param>
         /// <param name="filter">The APRS-IS filter string for server-side filtering.
-        /// Null sends no filter, which is not recommended for most clients and servers.</param>
+        /// Null sends no filter, which is not recommended for most clients and servers.
+        /// This parameter shouldn't include the `filter` at the start, just the logic string itself.</param>
         /// <returns>An async task.</returns>
         public async Task Receive(string callsign, string password, string server, string? filter)
         {
@@ -206,7 +207,8 @@
         /// <param name="callsign">The users callsign string.</param>
         /// <param name="password">The users password string.</param>
         /// <param name="filter">The APRS-IS filter string for server-side filtering.
-        /// Null sends no filter, which is not recommended for most clients and servers.</param>
+        /// Null sends no filter, which is not recommended for most clients and servers.
+        /// This parameter shouldn't include the `filter` at the start, just the logic string itself.</param>
         private void SendLogin(string callsign, string password, string? filter)
         {
             logger.LogInformation("Logging in to server.");
@@ -290,7 +292,7 @@
             /// <summary>
             /// This defines the default filter.
             /// </summary>
-            public const string DefaultFilter = "filter r/50.5039/4.4699/50";
+            public const string DefaultFilter = "r/50.5039/4.4699/50";
         }
     }
 }


### PR DESCRIPTION
## Description

As reported in #162 by @ShawnStoddard (thanks!), the default filter string in the CLI includes the word `filter`, which is later appended by the AprsIsClient. This PR removes that additional/unnecessary string and updates the docs to ensure it's clear that the filter string is just the logic string, not the extra "filter" word at the front.

This resolves #162

## Changes

* Remove additional "filter" word in default filter value
* Update docstrings for clarity

## Validation

* Manual testing ensures APRS-IS filtering is working correctly
* Manual testing ensures new output appears in `--help` flag to CLI
