### PR TITLE
Switch from FxCop to .NET Analyzers

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+# Don't want to ConfigureAwait(false) in application code
+# Also want to allow the test synchronization context to work, so don't do this in tests.
+[{src/APRSsharp/Program.cs,test/**.cs}]
+dotnet_diagnostic.CA2007.severity = none

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -13,11 +13,15 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Copyright (c) Cameron Bielstein 2020</Copyright>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisMode>All</AnalysisMode>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration.ToLower())' == 'release'">
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <MSBuildTreatWarningsAsErrors>True</MSBuildTreatWarningsAsErrors>
+    <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
   </PropertyGroup>
 
   <Import Project="Packages.props"/>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <NullableReferenceTypes>true</NullableReferenceTypes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/APRSsharp/Mode.cs
+++ b/src/APRSsharp/Mode.cs
@@ -18,5 +18,5 @@ public enum Mode
     /// <summary>
     /// Interfaces with a KISS TNC via serial connection
     /// </summary>
-    SERIAL_TNC,
+    SERIALTNC,
 }

--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -17,7 +17,7 @@
     /// The public class that will be called when building the console application.
     /// It is the main class that will have functionality of calling and decoding the packets.
     /// </summary>
-    public class Program
+    public static class Program
     {
         /// <summary>
         /// If true, display unsupported <see cref="InfoField"/> types as raw encoding.
@@ -30,6 +30,7 @@
         /// <param name="p">A <see cref="Packet"/> to be printed.</param>
         public static void PrintPacket(Packet p)
         {
+            ArgumentNullException.ThrowIfNull(p);
             if (!Program.displayUnsupported && p.InfoField is UnsupportedInfo)
             {
                 return;
@@ -104,6 +105,7 @@
         public static void Main(string[] args)
         {
             // Create a root command with some options
+#pragma warning disable CA1861 // Avoid constant arrays as arguments
             var rootCommand = new RootCommand
                 {
                 new Option<Mode>(
@@ -142,6 +144,7 @@
                     getDefaultValue: () => null,
                     description: "A serial port for use with serial TNCs."),
                 };
+#pragma warning restore CA1861 // Avoid constant arrays as arguments
             rootCommand.Description = "AprsSharp Console App";
 
             // The parameters of the handler method are matched according to the names of the options
@@ -173,7 +176,7 @@
                 {
                     break;
                 }
-                else if (string.Equals(callsign, "N0CALL", StringComparison.InvariantCultureIgnoreCase))
+                else if (string.Equals(callsign, "N0CALL", StringComparison.OrdinalIgnoreCase))
                 {
                     Console.WriteLine("You must supply your callsign to send packets.");
                 }
@@ -259,7 +262,7 @@
                     break;
                 }
 
-                case Mode.SERIAL_TNC:
+                case Mode.SERIALTNC:
                 {
                     if (serialPort == null)
                     {

--- a/src/AprsParser/AprsParser.csproj
+++ b/src/AprsParser/AprsParser.csproj
@@ -9,10 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="GeoCoordinate.NetStandard1" Version="1.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/KissTnc/KissTnc.csproj
+++ b/src/KissTnc/KissTnc.csproj
@@ -9,10 +9,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.IO.Ports" Version="5.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AprsIsClientUnitTests/AprsIsClientUnitTests.csproj
+++ b/test/AprsIsClientUnitTests/AprsIsClientUnitTests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Moq" Version="4.14.6" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -13,7 +13,7 @@ namespace AprsSharpUnitTests.AprsIsClient
     /// <summary>
     /// Unit tests for <see cref="AprsIsClient.Receive(string, string, string, string?)"/>.
     /// </summary>
-    [Collection(nameof(TimedTestCollection))]
+    [Collection(nameof(TimedTests))]
     public class ReceiveUnitTests
     {
         /// <summary>

--- a/test/AprsIsClientUnitTests/TimedTests.cs
+++ b/test/AprsIsClientUnitTests/TimedTests.cs
@@ -6,8 +6,8 @@ namespace AprsSharpUnitTests.AprsIsClient
     /// Test collection to disable test parallelism, which
     /// is required for set timeouts on tests.
     /// </summary>
-    [CollectionDefinition(nameof(TimedTestCollection), DisableParallelization = true)]
-    public class TimedTestCollection
+    [CollectionDefinition(nameof(TimedTests), DisableParallelization = true)]
+    public class TimedTests
     {
     }
 }

--- a/test/AprsParserUnitTests/AprsParserUnitTests.csproj
+++ b/test/AprsParserUnitTests/AprsParserUnitTests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
   </ItemGroup>

--- a/test/AprsParserUnitTests/AprsParserUnitTests.csproj
+++ b/test/AprsParserUnitTests/AprsParserUnitTests.csproj
@@ -12,10 +12,6 @@
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/test/AprsParserUnitTests/InfoField/MaidenheadBeaconInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/MaidenheadBeaconInfoUnitTests.cs
@@ -32,15 +32,15 @@
                 Assert.NotNull(mbi.Position);
 
                 // Coordinates not precise when coming from gridhead
-                double latitude = mbi?.Position?.Coordinates.Latitude ?? throw new Exception("Latitude should not be null");
-                double longitude = mbi?.Position?.Coordinates.Longitude ?? throw new Exception("Longitude should not be null");
+                double latitude = mbi.Position.Coordinates.Latitude;
+                double longitude = mbi.Position.Coordinates.Longitude;
                 Assert.Equal(51.98, Math.Round(latitude, 2));
                 Assert.Equal(-0.46, Math.Round(longitude, 2));
 
-                Assert.Equal("IO91SX", mbi?.Position?.EncodeGridsquare(6, false));
-                Assert.Equal('\\', mbi?.Position?.SymbolTableIdentifier);
-                Assert.Equal('.', mbi?.Position?.SymbolCode);
-                Assert.Equal("35 miles NNW of London", mbi?.Comment);
+                Assert.Equal("IO91SX", mbi.Position.EncodeGridsquare(6, false));
+                Assert.Equal('\\', mbi.Position.SymbolTableIdentifier);
+                Assert.Equal('.', mbi.Position.SymbolCode);
+                Assert.Equal("35 miles NNW of London", mbi.Comment);
             }
             else
             {

--- a/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/PositionInfoUnitTests.cs
@@ -29,19 +29,19 @@ namespace AprsSharpUnitTests.AprsParser
 
             if (p.InfoField is PositionInfo pi)
             {
-                Assert.Equal(new GeoCoordinate(49.0583, -72.0292), pi?.Position?.Coordinates);
-                Assert.Equal('/', pi?.Position?.SymbolTableIdentifier);
-                Assert.Equal('>', pi?.Position?.SymbolCode);
+                Assert.Equal(new GeoCoordinate(49.0583, -72.0292), pi.Position?.Coordinates);
+                Assert.Equal('/', pi.Position?.SymbolTableIdentifier);
+                Assert.Equal('>', pi.Position?.SymbolCode);
 
                 // This is using day/hour/minute encoding, so only check those
-                Assert.Equal(9, pi?.Timestamp?.DateTime.Day);
-                Assert.Equal(23, pi?.Timestamp?.DateTime.Hour);
-                Assert.Equal(45, pi?.Timestamp?.DateTime.Minute);
-                Assert.Equal(TimestampType.DHMz, pi?.Timestamp?.DecodedType);
-                Assert.Equal(DateTimeKind.Utc, pi?.Timestamp?.DateTime.Kind);
+                Assert.Equal(9, pi.Timestamp?.DateTime.Day);
+                Assert.Equal(23, pi.Timestamp?.DateTime.Hour);
+                Assert.Equal(45, pi.Timestamp?.DateTime.Minute);
+                Assert.Equal(TimestampType.DHMz, pi.Timestamp?.DecodedType);
+                Assert.Equal(DateTimeKind.Utc, pi.Timestamp?.DateTime.Kind);
 
-                Assert.Equal("Test1234", pi?.Comment);
-                Assert.False(pi?.HasMessaging);
+                Assert.Equal("Test1234", pi.Comment);
+                Assert.False(pi.HasMessaging);
             }
             else
             {

--- a/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/StatusInfoUnitTests.cs
@@ -28,14 +28,15 @@ namespace AprsSharpUnitTests.AprsParser
             if (p.InfoField is StatusInfo si)
             {
                 // Coordinates not precise when coming from gridhead
-                double latitude = si?.Position?.Coordinates.Latitude ?? throw new Exception("Latitude should not be null");
-                double longitude = si?.Position?.Coordinates.Longitude ?? throw new Exception("Longitude should not be null");
+                Assert.NotNull(si.Position);
+                double latitude = si.Position.Coordinates.Latitude;
+                double longitude = si.Position.Coordinates.Longitude;
                 Assert.Equal(51.98, Math.Round(latitude, 2));
                 Assert.Equal(-0.46, Math.Round(longitude, 2));
-                Assert.Equal("IO91SX", si?.Position?.EncodeGridsquare(6, false));
-                Assert.Equal('/', si?.Position?.SymbolTableIdentifier);
-                Assert.Equal('G', si?.Position?.SymbolCode);
-                Assert.Equal("My house", si?.Comment);
+                Assert.Equal("IO91SX", si.Position.EncodeGridsquare(6, false));
+                Assert.Equal('/', si.Position.SymbolTableIdentifier);
+                Assert.Equal('G', si.Position.SymbolCode);
+                Assert.Equal("My house", si.Comment);
             }
             else
             {

--- a/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
+++ b/test/AprsParserUnitTests/InfoField/WeatherInfoUnitTests.cs
@@ -317,10 +317,7 @@ namespace AprsSharpUnitTests.AprsParser
             int? expectedSnow,
             PacketType expectedPacketType)
         {
-            if (actual == null)
-            {
-                throw new ArgumentNullException(nameof(actual));
-            }
+            ArgumentNullException.ThrowIfNull(actual);
 
             Assert.Equal(expectedPacketType, actual.Type);
             Assert.Equal(expectedHasMessaging, actual.HasMessaging);
@@ -332,11 +329,11 @@ namespace AprsSharpUnitTests.AprsParser
             else
             {
                 Assert.NotNull(actual.Timestamp);
-                Assert.Equal(expectedTimestamp?.DecodedType, actual.Timestamp?.DecodedType);
-                Assert.Equal(expectedTimestamp?.DateTime.Day, actual.Timestamp?.DateTime.Day);
-                Assert.Equal(expectedTimestamp?.DateTime.Hour, actual.Timestamp?.DateTime.Hour);
-                Assert.Equal(expectedTimestamp?.DateTime.Minute, actual.Timestamp?.DateTime.Minute);
-                Assert.Equal(expectedTimestamp?.DateTime.Kind, actual.Timestamp?.DateTime.Kind);
+                Assert.Equal(expectedTimestamp.DecodedType, actual.Timestamp?.DecodedType);
+                Assert.Equal(expectedTimestamp.DateTime.Day, actual.Timestamp?.DateTime.Day);
+                Assert.Equal(expectedTimestamp.DateTime.Hour, actual.Timestamp?.DateTime.Hour);
+                Assert.Equal(expectedTimestamp.DateTime.Minute, actual.Timestamp?.DateTime.Minute);
+                Assert.Equal(expectedTimestamp.DateTime.Kind, actual.Timestamp?.DateTime.Kind);
             }
 
             Assert.Equal(expectedPosition.SymbolTableIdentifier, actual.Position.SymbolTableIdentifier);

--- a/test/AprsParserUnitTests/PacketAx25UnitTests.cs
+++ b/test/AprsParserUnitTests/PacketAx25UnitTests.cs
@@ -30,13 +30,13 @@ public class PacketAx25UnitTests
         Assert.Equal(destination, decodedPacket.Destination);
         Assert.Equal(path, decodedPacket.Path);
 
-        Assert.IsType<StatusInfo>(decodedPacket.InfoField);
-        var si = (StatusInfo)decodedPacket.InfoField;
-        Assert.NotNull(si);
-        Assert.Equal(DateTimeKind.Utc, si.Timestamp?.DateTime.Kind);
-        Assert.Equal(info.Timestamp?.DateTime.Day, si.Timestamp?.DateTime.Day);
-        Assert.Equal(info.Timestamp?.DateTime.Hour, si.Timestamp?.DateTime.Hour);
-        Assert.Equal(info.Timestamp?.DateTime.Minute, si.Timestamp?.DateTime.Minute);
+        var si = Assert.IsType<StatusInfo>(decodedPacket.InfoField);
+        Assert.NotNull(si.Timestamp);
+
+        Assert.Equal(DateTimeKind.Utc, si.Timestamp.DateTime.Kind);
+        Assert.Equal(info.Timestamp!.DateTime.Day, si.Timestamp.DateTime.Day);
+        Assert.Equal(info.Timestamp!.DateTime.Hour, si.Timestamp.DateTime.Hour);
+        Assert.Equal(info.Timestamp!.DateTime.Minute, si.Timestamp.DateTime.Minute);
         Assert.Equal(info.Comment, si.Comment);
         Assert.Equal(info.Position?.Coordinates, si.Position?.Coordinates);
     }

--- a/test/AprsParserUnitTests/PacketAx25UnitTests.cs
+++ b/test/AprsParserUnitTests/PacketAx25UnitTests.cs
@@ -31,7 +31,8 @@ public class PacketAx25UnitTests
         Assert.Equal(path, decodedPacket.Path);
 
         Assert.IsType<StatusInfo>(decodedPacket.InfoField);
-        var si = (StatusInfo)decodedPacket.InfoField ?? throw new Exception();
+        var si = (StatusInfo)decodedPacket.InfoField;
+        Assert.NotNull(si);
         Assert.Equal(DateTimeKind.Utc, si.Timestamp?.DateTime.Kind);
         Assert.Equal(info.Timestamp?.DateTime.Day, si.Timestamp?.DateTime.Day);
         Assert.Equal(info.Timestamp?.DateTime.Hour, si.Timestamp?.DateTime.Hour);

--- a/test/KissTncUnitTests/KissTncUnitTests.csproj
+++ b/test/KissTncUnitTests/KissTncUnitTests.csproj
@@ -11,10 +11,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
     <PackageReference Include="Moq" Version="4.14.6" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Description

FxCop is deprecated in favor of .NET Analyzers, [as per Microsoft](https://learn.microsoft.com/en-us/visualstudio/code-quality/migrate-from-legacy-analysis-to-net-analyzers?view=vs-2022).
This PR removes FxCop packages and enables .NET Analyzers across the board.
It also fixes any warnings from the new analyzers.

This resolves #27.

## Changes

* Removes FxCop packages
* Enables .NET Analyzers across the board
* Adds `.editorconfig` for some larger analysis configs
* Fixes warnings from new analyzers

## Validation

* New analyzers raised a bunch of new warnings
* Build and tests are now clean on my machine
* Ensured warnings are treated as error in release build (i.e. `dotnet build -c Release` )
