### PR TITLE
Update readme for .NET 8.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ this project.
 
 ### Dependencies
 
-The target is .NET 6.0 for development.
+The target is .NET 8.0 for development.
 
 ### Building
 


### PR DESCRIPTION
## Description

#163 changed this repo to a .NET8.0 build target, but missed updating the note on this in the readme.

## Changes

* Updates the readme to accurately say .NET8.0 for developers.

## Validation

* Markdown shows valid in my IDE
* Linting will happen in this PR
