### PR TITLE
AprsIsClient Reports Errors Instead of Logs

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -232,7 +232,7 @@
                 {
                     Console.WriteLine($"Connecting to APRS-IS server: {server}");
 
-                    using AprsIsClient n = new AprsIsClient(loggerFactory.CreateLogger<AprsIsClient>());
+                    using AprsIsClient n = new AprsIsClient();
                     n.ReceivedPacket += PrintPacket;
 
                     Task receive = n.Receive(callsign, password, server, filter);

--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -157,12 +157,12 @@
                                     SendLogin(callsign, password, filter);
                                 }
                             }
-                            else if (ReceivedPacket != null)
+                            else
                             {
                                 try
                                 {
                                     Packet p = new Packet(received);
-                                    ReceivedPacket.Invoke(p);
+                                    ReceivedPacket?.Invoke(p);
                                 }
                                 catch (Exception ex)
                                 {

--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -85,7 +85,7 @@
         /// <summary>
         /// Event raised when an error or exception is encountered during packet parsing.
         /// </summary>
-        public event HandleParseExcpetion? ParseFailure;
+        public event HandleParseExcpetion? DecodeFailed;
 
         /// <summary>
         /// Gets the state of this connection.
@@ -157,16 +157,19 @@
                                     SendLogin(callsign, password, filter);
                                 }
                             }
-                            else
+                            else if (ReceivedPacket != null)
                             {
+                                // Only attempt to decode if the user
+                                // wants to receive packets instead of
+                                // only TCP messages
                                 try
                                 {
                                     Packet p = new Packet(received);
-                                    ReceivedPacket?.Invoke(p);
+                                    ReceivedPacket.Invoke(p);
                                 }
                                 catch (Exception ex)
                                 {
-                                    ParseFailure?.Invoke(ex, received);
+                                    DecodeFailed?.Invoke(ex, received);
                                 }
                             }
                         }

--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -6,7 +6,6 @@
     using System.Threading.Tasks;
     using AprsSharp.AprsParser;
     using AprsSharp.Shared;
-    using Microsoft.Extensions.Logging;
 
     /// <summary>
     /// Delegate for handling a full string from a TCP client.
@@ -63,8 +62,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="AprsIsClient"/> class.
         /// </summary>
-        /// <param name="logger">An <see cref="ILogger{AprsIsClient}"/> for error/debug logging.</param>
-        public AprsIsClient(ILogger<AprsIsClient> logger)
+        public AprsIsClient()
             : this(new TcpConnection(), true)
         {
         }

--- a/src/AprsIsClient/AprsIsClient.cs
+++ b/src/AprsIsClient/AprsIsClient.cs
@@ -157,15 +157,14 @@
                                     SendLogin(callsign, password, filter);
                                 }
                             }
-                            else if (ReceivedPacket != null)
+                            else if (ReceivedPacket != null || DecodeFailed != null)
                             {
                                 // Only attempt to decode if the user
-                                // wants to receive packets instead of
-                                // only TCP messages
+                                // wants results from decode.
                                 try
                                 {
                                     Packet p = new Packet(received);
-                                    ReceivedPacket.Invoke(p);
+                                    ReceivedPacket?.Invoke(p);
                                 }
                                 catch (Exception ex)
                                 {

--- a/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
+++ b/test/AprsIsClientUnitTests/AprsIsClientUnitTests.cs
@@ -21,7 +21,7 @@ namespace AprsSharpUnitTests.AprsIsClient
         {
             Mock<ITcpConnection> mockTcpConnection = new Mock<ITcpConnection>();
             mockTcpConnection.SetupGet(mock => mock.Connected).Returns(true);
-            using AprsIsClient client = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using AprsIsClient client = new AprsIsClient(mockTcpConnection.Object);
 
             Task receiveTask = client.Receive("callsign", "password", "server", "filter");
 

--- a/test/AprsIsClientUnitTests/DisposeUnitTests.cs
+++ b/test/AprsIsClientUnitTests/DisposeUnitTests.cs
@@ -24,7 +24,7 @@ namespace AprsSharpUnitTests.AprsIsClient
         {
             var mockTcpConnection = new Mock<ITcpConnection>();
 
-            using (AprsIsClient connection = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object, clientShouldDispose))
+            using (AprsIsClient connection = new AprsIsClient(mockTcpConnection.Object, clientShouldDispose))
             {
             }
 

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -6,7 +6,6 @@ namespace AprsSharpUnitTests.AprsIsClient
     using AprsSharp.AprsIsClient;
     using AprsSharp.AprsParser;
     using AprsSharp.Shared;
-    using Microsoft.Extensions.Logging.Abstractions;
     using Moq;
     using Xunit;
 

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -128,10 +128,10 @@ namespace AprsSharpUnitTests.AprsIsClient
         /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
         [Theory(Timeout = 500)]
         [InlineData("# logresp N0CALL unverified, server T2ONTARIO", "T2ONTARIO")]
+        [InlineData("# logresp N0CALL verified, server T2ONTARIO", "T2ONTARIO")]
         [InlineData("# logresp N0CALL unverified, server T2BRAZIL", "T2BRAZIL")]
-        [InlineData("# logresp N0CALL unverified, server", null)]
-        [InlineData("# logresp", null)]
-        public async Task ReceiveSetConnectedServerProperty(string loginResponse, string? expected)
+        [InlineData("# logresp N0CALL unverified, server T2BRAZIL serverCommand", "T2BRAZIL")]
+        public async Task ReceiveSetConnectedServerProperty(string loginResponse, string expected)
         {
             // Mock underlying TCP connection
             var mockTcpConnection = new Mock<ITcpConnection>();
@@ -158,7 +158,7 @@ namespace AprsSharpUnitTests.AprsIsClient
             // Wait to ensure the messages are sent and received
             await loggedIn.Task;
 
-            // Assert the ConnectedServer property was set to the correct server or null as appropriate.
+            // Assert the ConnectedServer property was set to the correct server name.
             Assert.Equal(expected, aprsIs.ConnectedServer);
         }
 

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -34,7 +34,7 @@ namespace AprsSharpUnitTests.AprsIsClient
             mockTcpConnection.SetupGet(mock => mock.Connected).Returns(true);
 
             // Create connection and register a callback
-            using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -76,7 +76,7 @@ namespace AprsSharpUnitTests.AprsIsClient
                 .Returns(loginResponse);
 
             // Create connection and register callbacks
-            using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
             aprsIs.ReceivedTcpMessage += (string message) =>
             {
                 tcpMessagesReceived.Add(message);
@@ -144,7 +144,7 @@ namespace AprsSharpUnitTests.AprsIsClient
             TaskCompletionSource loggedIn = new TaskCompletionSource();
 
             // Create connection and register callbacks
-            using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
             aprsIs.ChangedState += (ConnectionState newState) =>
             {
                 if (newState == ConnectionState.LoggedIn)
@@ -182,7 +182,7 @@ namespace AprsSharpUnitTests.AprsIsClient
             mockTcpConnection.SetupGet(mock => mock.Connected).Returns(true);
 
             // Create connection and register a callback
-            using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
             aprsIs.ReceivedPacket += (Packet p) =>
             {
                 receivedPacket = p;
@@ -230,7 +230,7 @@ namespace AprsSharpUnitTests.AprsIsClient
 #pragma warning restore CA2201 // Do not raise reserved exception types
 
             // Create connection and register callback
-            using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
             aprsIs.ChangedState += (ConnectionState newState) =>
             {
                 stateChangesReceived.Add(newState);
@@ -285,7 +285,7 @@ namespace AprsSharpUnitTests.AprsIsClient
 #pragma warning restore CA2201 // Do not raise reserved exception types
 
             // Create connection and register callbacks
-            using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
             aprsIs.ChangedState += (ConnectionState newState) =>
             {
                 stateChangesReceived.Add(newState);
@@ -345,7 +345,7 @@ namespace AprsSharpUnitTests.AprsIsClient
                 .Returns(false);
 
             // Create connection and register callbacks
-            using var aprsIs = new AprsIsClient(NullLogger<AprsIsClient>.Instance, mockTcpConnection.Object);
+            using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
             aprsIs.ChangedState += (ConnectionState newState) =>
             {
                 stateChangesReceived.Add(newState);

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -407,9 +407,6 @@ namespace AprsSharpUnitTests.AprsIsClient
                 eventHandled.SetResult();
             };
 
-            // Create a received callback to trigger decode
-            aprsIs.ReceivedPacket += (p) => { };
-
             // Receive some packets from it.
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);
 

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -400,12 +400,15 @@ namespace AprsSharpUnitTests.AprsIsClient
 
             // Create connection and register a callback
             using var aprsIs = new AprsIsClient(mockTcpConnection.Object);
-            aprsIs.ParseFailure += (Exception ex, string s) =>
+            aprsIs.DecodeFailed += (Exception ex, string s) =>
             {
                 reportedExceptions.Add(ex);
                 failedDecodes.Add(s);
                 eventHandled.SetResult();
             };
+
+            // Create a received callback to trigger decode
+            aprsIs.ReceivedPacket += (p) => { };
 
             // Receive some packets from it.
             _ = aprsIs.Receive("N0CALL", "-1", "example.com", null);

--- a/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
+++ b/test/AprsIsClientUnitTests/ReceiveUnitTests.cs
@@ -373,5 +373,15 @@ namespace AprsSharpUnitTests.AprsIsClient
             mockTcpConnection.VerifyGet(mock => mock.Connected, Times.Exactly(5));
             mockTcpConnection.Verify(mock => mock.ReceiveString(), Times.Exactly(4));
         }
+
+        /// <summary>
+        /// Tests that an event is raised on a failed decode.
+        /// </summary>
+        /// <returns>A <see cref="Task"/> representing the asynchronous unit test.</returns>
+        [Fact(Timeout = 500)]
+        public async Task EventRaisedOnFailedDecode()
+        {
+            throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
## Description

This PR moves from using `ILogger` to log issues internally in the class to creating an event so that client code can act on them. Another major benefit of this approach is eliminating required parameters to the constructor, which makes it even easier to get started.

## Changes

1. Moves APRS-IS decode failures to report via an event rather than internal logging
2. Removes the required log constructor argument to create an empty constructor
3. Sets up a new test for these things
4. Updates server name parsing logic to be more accurate to servers

## Validation

* New test passes
* All existing tests pass