### PR TITLE
Display Parse Failures

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -141,8 +141,7 @@
                     description: "A serial port for use with serial TNCs."),
                 new Option(
                     aliases: new string[] { "--display-parse-failures" },
-                    description: "If specified, prints packets that failed to parse. Helpful for development."
-                ),
+                    description: "If specified, prints packets that failed to parse. Helpful for development."),
                 };
 #pragma warning restore CA1861 // Avoid constant arrays as arguments
             rootCommand.Name = "APRSsharp";


### PR DESCRIPTION
## Description

After #174 , verbose printout was disabled. This switches to a new parameter and method of printing failures. It does that by introducing `--display-parse-failures` flag on the CLI and hooking up to the new event logic from #174.

This removes `--verbosity` and `-v` flags.

## Changes

* Remove `--verbosity` and `-v` flags from CLI
* Add `--display-parse-failures` flag to CLI for similar functionality
* Hook up `--display-parse-failures` logic to new event-driven exception flow in `AprsIsClient`

## Validation

* Builds and runs on local machine