### PR TITLE
Remove Unnecessary Package Reference from AprsIsClient

### DIFF
--- a/src/AprsIsClient/AprsIsClient.csproj
+++ b/src/AprsIsClient/AprsIsClient.csproj
@@ -5,10 +5,6 @@
     <ProjectReference Include="..\Shared\Shared.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
-  </ItemGroup>
-
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <PackageId>AprsSharp.AprsIsClient</PackageId>


### PR DESCRIPTION
## Description

Removes a package reference that is unnecessary after the work in #174 but was missed in that PR.

## Validation

* Build is successful
