### PR TITLE
Remove Required TcpConnection Object from TcpTnc

### DIFF
--- a/src/APRSsharp/Program.cs
+++ b/src/APRSsharp/Program.cs
@@ -285,10 +285,7 @@
                 {
                     Console.WriteLine($"Connecting to KISS TNC via TCP: {server}:{port}");
 
-                    using TcpConnection tcp = new TcpConnection();
-                    tcp.Connect(server, port);
-                    using Tnc tnc = new TcpTnc(tcp, 0);
-
+                    using Tnc tnc = new TcpTnc(server, port, 0);
                     RunTncMode(tnc, callsign, displayParseFailures);
 
                     break;

--- a/src/KissTnc/TcpTnc.cs
+++ b/src/KissTnc/TcpTnc.cs
@@ -8,16 +8,22 @@ namespace AprsSharp.KissTnc
     /// </summary>
     public sealed class TcpTnc : Tnc
     {
+        [System.Diagnostics.CodeAnalysis.SuppressMessage(
+            "IDisposableAnalyzers.Correctness",
+            "IDISP008:Don't assign member with injected and created disposables",
+            Justification = "Used for testing, disposal managed by the tcpConnectionInjected bool.")]
         private readonly ITcpConnection tcpConnection;
+        private readonly bool tcpConnectionInjected;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TcpTnc"/> class.
         /// </summary>
         /// <param name="tcpConnection">A <see cref="ITcpConnection"/> to communicate with the TNC.</param>
-        /// <param name="tncPort">Por the remote TNC should use to communicate to the radio.</param>
+        /// <param name="tncPort">Port the remote TNC should use to communicate to the radio. Part of the KISS protocol.</param>
         public TcpTnc(ITcpConnection tcpConnection, byte tncPort)
             : base(tncPort)
         {
+            tcpConnectionInjected = true;
             this.tcpConnection = tcpConnection ?? throw new ArgumentNullException(nameof(tcpConnection));
 
             if (!this.tcpConnection.Connected)
@@ -28,9 +34,33 @@ namespace AprsSharp.KissTnc
             this.tcpConnection.AsyncReceive(bytes => DecodeReceivedData(bytes));
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TcpTnc"/> class.
+        /// </summary>
+        /// <param name="address">The address (e.g. IP or domain name) of the TCP server.</param>
+        /// <param name="tcpPort">The TCP port for connection to the TCP server.</param>
+        /// <param name="tncPort">The TNC port used for connection to the radio. Part of the KISS protocol.</param>
+        public TcpTnc(string address, int tcpPort, byte tncPort)
+            : base(tncPort)
+        {
+            tcpConnectionInjected = false;
+            tcpConnection = new TcpConnection();
+            tcpConnection.Connect(address, tcpPort);
+
+            tcpConnection.AsyncReceive(bytes => DecodeReceivedData(bytes));
+        }
+
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
+            if (disposing)
+            {
+                if (tcpConnectionInjected == false)
+                {
+                    tcpConnection.Dispose();
+                }
+            }
+
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
## Description

The `TcpConnection` object exists to allow easy testing. However, it isn't super useful for users of the package..and requires extra code and understanding extra concepts. This PR adds the ability of `TcpTnc` to manage its own `TcpConnection` while preserving the ability to pass in an object for testing.

## Changes

* Allow `TcpTnc` construction without a `TcpConnection` object (managed inside the `TcpTnc` object directly)
* Update in CLI app to use the simpler constructor

## Validation

* CI passes
* Manual test against a TCP KISS TNC is functioning well
