### PR TITLE
Add Note About Versioning to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,15 @@ community for the community.
 Currently, all packages from this repo change version together.
 Although that isn't fully ideal, it is easy and works for now.
 
-The goal is for v1.0.0 to come when the APRS v1 spec is implemented, then increment up from there.
+The goal is for v1.0.0 to come when the APRS v1 spec is implemented, then
+increment up from there.
 
 Until then, this packages from this repo use a slightly modified [semver](https://semver.org/).
 For version x.y.z:
 
 * x stays 0 for pre-release (again, until the APRSv1 spec is implemented).
-* y updates for any breaking changes (and there may be breaking changes during pre-release development).
+* y updates for any breaking changes (and there may be breaking changes during
+pre-release development).
 * z updates with new non-breaking functionality, bug fixes, or other changes.
 
 This is essentially semver shifted to the right.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,22 @@ visualizing APRS digital packets in a straight-forward manner.
 This project is provided as [open source](LICENSE) and developed by the
 community for the community.
 
+## Note on Versioning
+
+Currently, all packages from this repo change version together.
+Although that isn't fully ideal, it is easy and works for now.
+
+The goal is for v1.0.0 to come when the APRS v1 spec is implemented, then increment up from there.
+
+Until then, this packages from this repo use a slightly modified [semver](https://semver.org/).
+For version x.y.z:
+
+* x stays 0 for pre-release (again, until the APRSv1 spec is implemented).
+* y updates for any breaking changes (and there may be breaking changes during pre-release development).
+* z updates with new non-breaking functionality, bug fixes, or other changes.
+
+This is essentially semver shifted to the right.
+
 ### Further Documentation
 
 See supplemental documentation for APRS# constituent projects:


### PR DESCRIPTION
## Description

During pre-production development, this repo is using a slightly modified version of semver. This hasn't been called out to contributors and users yet, so I'm adding it to the readme now.

## Changes

* Add note about versioning strategy to main readme