### PR TITLE
Fix README Ordering of Version Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ visualizing APRS digital packets in a straight-forward manner.
 This project is provided as [open source](LICENSE) and developed by the
 community for the community.
 
+### Further Documentation
+
+See supplemental documentation for APRS# constituent projects:
+
+* [AprsParser](src/AprsParser/AprsParser.md)
+* [KissTnc](src/KissTnc/KissTnc.md)
+* [AprsIsClient](src/AprsIsClient/AprsIsClient.md)
+
 ## Note on Versioning
 
 Currently, all packages from this repo change version together.
@@ -41,14 +49,6 @@ pre-release development).
 * z updates with new non-breaking functionality, bug fixes, or other changes.
 
 This is essentially semver shifted to the right.
-
-### Further Documentation
-
-See supplemental documentation for APRS# constituent projects:
-
-* [AprsParser](src/AprsParser/AprsParser.md)
-* [KissTnc](src/KissTnc/KissTnc.md)
-* [AprsIsClient](src/AprsIsClient/AprsIsClient.md)
 
 ## Contributions
 


### PR DESCRIPTION
## Description

#182 added the version note in the middle of another section. This is what happens when I review my own code late at night. This fixes it by moving the versioning section down to an appropriate spot.

## Changes

* Move versioning section further down readme
